### PR TITLE
Feature/14 retain symbology

### DIFF
--- a/app/client/src/components/Publish.tsx
+++ b/app/client/src/components/Publish.tsx
@@ -147,6 +147,7 @@ function Publish() {
     partialPlanAttributes,
   } = useContext(PublishContext);
   const {
+    defaultSymbols,
     edits,
     setEdits,
     layers,
@@ -1543,8 +1544,20 @@ function Publish() {
         if (!type.value) return;
 
         const sampleType = userDefinedAttributes.sampleTypes[type.value];
+        const symbolTypeUuid = sampleType.attributes.TYPEUUID ?? 'Samples';
+        const defaultSymbol =
+          defaultSymbols.symbols[
+            defaultSymbols.symbols.hasOwnProperty(symbolTypeUuid)
+              ? symbolTypeUuid
+              : 'Samples'
+          ];
         const item = {
-          attributes: sampleType.attributes,
+          attributes: {
+            ...sampleType.attributes,
+            SYMBOLCOLOR: JSON.stringify(defaultSymbol.color),
+            SYMBOLOUTLINE: JSON.stringify(defaultSymbol.outline),
+            SYMBOLTYPE: defaultSymbol.type,
+          },
         };
         if (publishSamplesMode === 'new') {
           changes.adds.push(item);
@@ -1592,8 +1605,21 @@ function Publish() {
               if (!type.value) return;
 
               const sampleType = userDefinedAttributes.sampleTypes[type.value];
+              const symbolTypeUuid =
+                sampleType.attributes.TYPEUUID ?? 'Samples';
+              const defaultSymbol =
+                defaultSymbols.symbols[
+                  defaultSymbols.symbols.hasOwnProperty(symbolTypeUuid)
+                    ? symbolTypeUuid
+                    : 'Samples'
+                ];
               const item = {
-                attributes: sampleType.attributes,
+                attributes: {
+                  ...sampleType.attributes,
+                  SYMBOLCOLOR: JSON.stringify(defaultSymbol.color),
+                  SYMBOLOUTLINE: JSON.stringify(defaultSymbol.outline),
+                  SYMBOLTYPE: defaultSymbol.type,
+                },
               };
               const typeUuid = item.attributes.TYPEUUID || '';
 
@@ -1625,6 +1651,7 @@ function Publish() {
         });
       });
   }, [
+    defaultSymbols,
     layerProps,
     portal,
     publishSampleTableMetaData,

--- a/app/client/src/components/SearchPanel.tsx
+++ b/app/client/src/components/SearchPanel.tsx
@@ -1267,7 +1267,6 @@ function ResultCard({ result }: ResultCardProps) {
                   graphic.popupTemplate = popupTemplate;
 
                   const newGraphic: any = {
-                    // attributes: { ...graphic.attributes },
                     geometry: graphic.geometry,
                     symbol: graphic.symbol,
                     popupTemplate: graphic.popupTemplate,
@@ -1292,14 +1291,15 @@ function ResultCard({ result }: ResultCardProps) {
                     };
                   }
 
-                  newGraphic.symbol = newDefaultSymbols.symbols['Samples'];
-                  if (
-                    newDefaultSymbols.symbols.hasOwnProperty(
-                      feature.attributes.TYPEUUID,
-                    )
-                  ) {
-                    graphic.symbol =
-                      newDefaultSymbols.symbols[feature.attributes.TYPEUUID];
+                  const typeUuid = feature.attributes.TYPEUUID;
+                  newGraphic.symbol =
+                    newDefaultSymbols.symbols[
+                      newDefaultSymbols.symbols.hasOwnProperty(typeUuid)
+                        ? typeUuid
+                        : 'Samples'
+                    ];
+                  if (newDefaultSymbols.symbols.hasOwnProperty(typeUuid)) {
+                    graphic.symbol = newDefaultSymbols.symbols[typeUuid];
                   }
 
                   zoomToGraphics.push(graphic);

--- a/app/client/src/components/SearchPanel.tsx
+++ b/app/client/src/components/SearchPanel.tsx
@@ -1556,6 +1556,10 @@ function ResultCard({ result }: ResultCardProps) {
             // define items used for updating states
             const newAttributes: Attributes = {};
             const newUserSampleTypes: SampleSelectType[] = [];
+            const newDefaultSymbols: DefaultSymbolsType = {
+              editCount: defaultSymbols.editCount + 1,
+              symbols: { ...defaultSymbols.symbols },
+            };
 
             // create the user defined sample types to be added to TOTS
             responses.forEach((layerFeatures) => {
@@ -1667,6 +1671,19 @@ function ResultCard({ result }: ResultCardProps) {
                     },
                   };
                 }
+
+                // Add the symbol symbology
+                if (
+                  attributes.SYMBOLTYPE &&
+                  attributes.SYMBOLCOLOR &&
+                  attributes.SYMBOLOUTLINE
+                ) {
+                  newDefaultSymbols.symbols[attributes.TYPEUUID] = {
+                    type: attributes.SYMBOLTYPE,
+                    color: JSON.parse(attributes.SYMBOLCOLOR),
+                    outline: JSON.parse(attributes.SYMBOLOUTLINE),
+                  };
+                }
               });
             });
 
@@ -1706,6 +1723,8 @@ function ResultCard({ result }: ResultCardProps) {
                 };
               });
             }
+
+            setDefaultSymbols(newDefaultSymbols);
 
             // reset the status
             setStatus('');

--- a/app/client/src/utils/arcGisRestUtils.ts
+++ b/app/client/src/utils/arcGisRestUtils.ts
@@ -731,7 +731,10 @@ function createFeatureTables(
 
     tableParams.push({
       ...layerProps.data.defaultTableProps,
-      fields: layerProps.data.defaultFields,
+      fields: [
+        ...layerProps.data.defaultFields,
+        ...layerProps.data.additionalTableFields,
+      ],
       type: 'Table',
       name: serviceMetaData.label,
       description: serviceMetaData.description,

--- a/app/server/app/public/data/config/layerProps.json
+++ b/app/server/app/public/data/config/layerProps.json
@@ -372,6 +372,44 @@
       "defaultValue": 0
     }
   ],
+  "additionalTableFields": [
+    {
+      "name": "SYMBOLCOLOR",
+      "type": "esriFieldTypeString",
+      "actualType": "nvarchar",
+      "alias": "COLOR",
+      "sqlType": "sqlTypeNVarchar",
+      "length": 255,
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "SYMBOLOUTLINE",
+      "type": "esriFieldTypeString",
+      "actualType": "nvarchar",
+      "alias": "SYMBOLOUTLINE",
+      "sqlType": "sqlTypeNVarchar",
+      "length": 255,
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "SYMBOLTYPE",
+      "type": "esriFieldTypeString",
+      "actualType": "nvarchar",
+      "alias": "SYMBOLTYPE",
+      "sqlType": "sqlTypeNVarchar",
+      "length": 255,
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    }
+  ],
   "defaultLayerProps": {
     "type": "Feature Layer",
     "editFieldsInfo": {


### PR DESCRIPTION
## Related Issues:
* [TOTS-14](https://ergcloud.atlassian.net/browse/TOTS-14)

## Main Changes:
* Fixed an issue where pulling down existing sample plans would not retain the symbol colors (i.e., graphics are always gray with black border).
* Fixed an issue with saving custom sample types not saving the symbol colors.

## Steps To Test:
1. Pull down a layer with custom symbol colors (create one if you don't already have one)
2. Verify the symbols display the colors correctly
3. Save a custom sample type with non-default colors
4. Pull in that new custom sample type and plot one on the map
5. Verify the symbol matches the colors

