### PR TITLE
Bugfix/35 allow updating webmaps

### DIFF
--- a/app/client/src/components/ConfigureOutput.tsx
+++ b/app/client/src/components/ConfigureOutput.tsx
@@ -267,12 +267,10 @@ function ConfigureOutput() {
 
       if (applicableLayerTypesAgoWebMap.includes(l.layerType)) {
         item.onWebMap = 1;
-        item.onWebScene = 0;
         webMapRefLayers.push(item);
       }
 
       if (applicableLayerTypesAgoWebScene.includes(l.layerType)) {
-        item.onWebMap = 0;
         item.onWebScene = 1;
         webMapRefLayers.push(item);
       }
@@ -320,7 +318,6 @@ function ConfigureOutput() {
           applicableLayerTypesUrlWebMap.includes(l.layerType))
       ) {
         item.onWebMap = 1;
-        item.onWebScene = 0;
         webMapRefLayers.push(item);
       }
 
@@ -329,7 +326,6 @@ function ConfigureOutput() {
         (l.type === 'ArcGIS' &&
           applicableLayerTypesUrlWebScene.includes(l.layerType))
       ) {
-        item.onWebMap = 0;
         item.onWebScene = 1;
         webSceneRefLayers.push(item);
       }
@@ -346,12 +342,9 @@ function ConfigureOutput() {
         layer: l,
         type: 'file',
         onWebMap: 1,
-        onWebScene: 0,
+        onWebScene: 1,
       };
       webMapRefLayers.push(item);
-
-      item.onWebMap = 0;
-      item.onWebScene = 1;
       webSceneRefLayers.push(item);
     });
 

--- a/app/client/src/components/ConfigureOutput.tsx
+++ b/app/client/src/components/ConfigureOutput.tsx
@@ -144,6 +144,7 @@ const nextInstructionStyles = css`
 const infoIconStyles = css`
   margin-left: 10px;
   color: #19a3dd;
+  pointer-events: all;
 `;
 
 const nestedAccordionStyles = css`

--- a/app/client/src/components/Publish.tsx
+++ b/app/client/src/components/Publish.tsx
@@ -1031,24 +1031,11 @@ function Publish() {
       });
     });
 
-    if (
-      layerEdits.adds.length === 0 &&
-      layerEdits.updates.length === 0 &&
-      layerEdits.deletes.length === 0
-    ) {
-      setPublishPartialResponse({
-        status: 'success',
-        summary: { success: '', failed: '' },
-        rawData: {},
-      });
-      return;
-    } else {
-      setPublishPartialResponse({
-        status: 'fetching',
-        summary: { success: '', failed: '' },
-        rawData: null,
-      });
-    }
+    setPublishPartialResponse({
+      status: 'fetching',
+      summary: { success: '', failed: '' },
+      rawData: null,
+    });
 
     publish({
       portal,

--- a/app/client/src/components/SearchPanel.tsx
+++ b/app/client/src/components/SearchPanel.tsx
@@ -1183,14 +1183,11 @@ function ResultCard({ result }: ResultCardProps) {
       });
 
       const resSampleTypes: any[] = [];
+      const resRefLayersTypes: any[] = [];
       featureLayersRes.tables.forEach((table: any) => {
         if (table.name.endsWith('-sample-types')) {
           resSampleTypes.push(table);
         }
-      });
-
-      const resRefLayersTypes: any[] = [];
-      featureLayersRes.tables.forEach((table: any) => {
         if (table.name.endsWith('-reference-layers')) {
           resRefLayersTypes.push(table);
         }

--- a/app/client/src/utils/arcGisRestUtils.ts
+++ b/app/client/src/utils/arcGisRestUtils.ts
@@ -1917,7 +1917,7 @@ function addWebScene({
     appendEnvironmentObjectParam(data);
 
     const url = existingWebScene
-      ? `${existingWebScene.itemUrl}/update`
+      ? `${existingWebScene.userItemUrl}/update`
       : `${portal.user.userContentUrl}/addItem`;
 
     fetchPost(url, data)


### PR DESCRIPTION
## Related Issues:
* [TOTS-35](https://ergcloud.atlassian.net/browse/TOTS-35)

## Main Changes:
* Added code to the publish logic to update the web map/scene if it already exists.
* Fixed an issue of the tooltip not showing in accordion headers.
* Fixed issue of web scene reference layer select menu being empty.
* Updated the publish to allow updating even if the user didn't add, update, or delete any samples.

