### PR TITLE
Bugfix/47 attribute mismatch ago

### DIFF
--- a/app/client/src/components/SearchPanel.tsx
+++ b/app/client/src/components/SearchPanel.tsx
@@ -1620,7 +1620,7 @@ function ResultCard({ result }: ResultCardProps) {
       // validate the area and attributes of features of the uploads. If there is an
       // issue, display a popup asking the user if they would like the samples to be updated.
       if (zoomToGraphics.length > 0) {
-        const output = sampleValidation(zoomToGraphics, true);
+        const output = sampleValidation(zoomToGraphics, true, false);
 
         if (output?.areaOutOfTolerance || output?.attributeMismatch) {
           setOptions({

--- a/app/client/src/utils/hooks.tsx
+++ b/app/client/src/utils/hooks.tsx
@@ -425,8 +425,13 @@ export function useGeometryTools() {
   const sampleValidation: (
     graphics: __esri.Graphic[],
     isFullGraphic?: boolean,
+    hasAllAttributes?: boolean,
   ) => SampleIssuesOutput = useCallback(
-    (graphics: __esri.Graphic[], isFullGraphic: boolean = false) => {
+    (
+      graphics: __esri.Graphic[],
+      isFullGraphic: boolean = false,
+      hasAllAttributes: boolean = true,
+    ) => {
       let areaOutOfTolerance = false;
       let attributeMismatch = false;
 
@@ -491,6 +496,8 @@ export function useGeometryTools() {
             ];
           Object.keys(predefinedAttributes).forEach((key) => {
             if (!sampleTypeContext.data.attributesToCheck.includes(key)) return;
+            if (!hasAllAttributes && !graphic.attributes.hasOwnProperty(key))
+              return;
             if (
               graphic.attributes.hasOwnProperty(key) &&
               predefinedAttributes[key] === graphic.attributes[key]

--- a/app/server/app/public/data/config/layerProps.json
+++ b/app/server/app/public/data/config/layerProps.json
@@ -115,6 +115,17 @@
       "defaultValue": null
     },
     {
+      "name": "AC",
+      "type": "esriFieldTypeInteger",
+      "actualType": "int",
+      "alias": "Equivalent TOTS Samples",
+      "sqlType": "sqlTypeInteger",
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
       "name": "TTPK",
       "type": "esriFieldTypeDouble",
       "actualType": "double",
@@ -370,6 +381,18 @@
       "editable": false,
       "domain": null,
       "defaultValue": 0
+    },
+    {
+      "name": "ID",
+      "type": "esriFieldTypeString",
+      "actualType": "nvarchar",
+      "alias": "ID",
+      "sqlType": "sqlTypeNVarchar",
+      "length": 5000,
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
     }
   ],
   "additionalTableFields": [


### PR DESCRIPTION
## Related Issues:
* https://ergcloud.atlassian.net/browse/TOTS-47

## Main Changes:
* Fixed issue of Sample attributes mismatch message always being displayed when pulling in layers from AGO that were published to AGO. 
  * This was showing up because we don't publish all of the attributes to AGO. I had to update the code to only check those attributes that were published.
* Fixed issue of `ID` and `Equivalent TOTS Samples` fields showing up twice in the `Add User-Defined Attributtes` table.
