### PR TITLE
Feature/46 flaky select tools

### DIFF
--- a/app/client/src/components/MapWidgets.tsx
+++ b/app/client/src/components/MapWidgets.tsx
@@ -312,7 +312,6 @@ function MapWidgets({ mapView, sceneView }: Props) {
     mapView.ui.add(widget2d, { position: 'top-right', index: 0 });
 
     const widget3d = buildWidget(sceneView, sketchLayer);
-    sceneView.ui.add(widget3d, { position: 'top-right', index: 0 });
 
     setSketchWidget({
       '2d': widget2d,


### PR DESCRIPTION
## Related Issues:
* [TOTS-46](https://ergcloud.atlassian.net/browse/TOTS-46)

## Main Changes:
* Added the ability to select multiple samples by holding Ctrl or Shift and then clicking on the samples. 
* Removed the rectangle/lasso selection tools from the 3D viewer, since [esri does not support those tools in 3D](https://community.esri.com/t5/arcgis-javascript-maps-sdk-questions/rectangle-and-lasso-selection-tools-not-showing-in/m-p/1284068#M81003).

