### PR TITLE
Bugfix/12 map overflows epa footer

### DIFF
--- a/app/client/src/components/Map.tsx
+++ b/app/client/src/components/Map.tsx
@@ -23,7 +23,7 @@ import { getGraphicsArray } from 'utils/sketchUtils';
 // --- styles (Map) ---
 const mapStyles = (height: number) => {
   return css`
-    height: calc(100% - ${height}px);
+    height: ${height}px;
     background-color: whitesmoke;
   `;
 };

--- a/app/client/src/components/Toolbar.tsx
+++ b/app/client/src/components/Toolbar.tsx
@@ -442,7 +442,6 @@ function Toolbar() {
     sceneView,
     displayDimensions,
     setDisplayDimensions,
-    setDisplayDimensionsChanged,
     terrain3dVisible,
     setTerrain3dVisible,
     viewUnderground3d,
@@ -864,10 +863,7 @@ function Toolbar() {
                 name="dimension"
                 value="2d"
                 checked={displayDimensions === '2d'}
-                onChange={(ev) => {
-                  setDisplayDimensions('2d');
-                  setDisplayDimensionsChanged(true);
-                }}
+                onChange={(ev) => setDisplayDimensions('2d')}
               />
               <label htmlFor="dimension-2d">2D</label>
               <br />
@@ -881,7 +877,6 @@ function Toolbar() {
                 onChange={(ev) => {
                   setDisplayDimensions('3d');
                   setDisplayGeometryType('points');
-                  setDisplayDimensionsChanged(true);
                 }}
               />
               <label htmlFor="dimension-3d">3D</label>

--- a/app/client/src/contexts/Sketch.tsx
+++ b/app/client/src/contexts/Sketch.tsx
@@ -89,8 +89,6 @@ type SketchType = {
   setDisplayGeometryType: Dispatch<SetStateAction<'points' | 'polygons'>>;
   displayDimensions: '2d' | '3d';
   setDisplayDimensions: Dispatch<SetStateAction<'2d' | '3d'>>;
-  displayDimensionsChanged: boolean;
-  setDisplayDimensionsChanged: Dispatch<SetStateAction<boolean>>;
   terrain3dVisible: boolean;
   setTerrain3dVisible: Dispatch<SetStateAction<boolean>>;
   viewUnderground3d: boolean;
@@ -156,8 +154,6 @@ export const SketchContext = createContext<SketchType>({
   setDisplayGeometryType: () => {},
   displayDimensions: '2d',
   setDisplayDimensions: () => {},
-  displayDimensionsChanged: false,
-  setDisplayDimensionsChanged: () => {},
   terrain3dVisible: true,
   setTerrain3dVisible: () => {},
   viewUnderground3d: false,
@@ -237,8 +233,6 @@ export function SketchProvider({ children }: Props) {
     'points' | 'polygons'
   >('points');
   const [displayDimensions, setDisplayDimensions] = useState<'2d' | '3d'>('2d');
-  const [displayDimensionsChanged, setDisplayDimensionsChanged] =
-    useState(false);
   const [terrain3dVisible, setTerrain3dVisible] = useState(true);
   const [viewUnderground3d, setViewUnderground3d] = useState(false);
 
@@ -400,8 +394,6 @@ export function SketchProvider({ children }: Props) {
         setDisplayGeometryType,
         displayDimensions,
         setDisplayDimensions,
-        displayDimensionsChanged,
-        setDisplayDimensionsChanged,
         terrain3dVisible,
         setTerrain3dVisible,
         viewUnderground3d,

--- a/app/client/src/utils/hooks.tsx
+++ b/app/client/src/utils/hooks.tsx
@@ -2480,7 +2480,6 @@ function useDisplayModeStorage() {
   const {
     displayDimensions,
     setDisplayDimensions,
-    setDisplayDimensionsChanged,
     displayGeometryType,
     setDisplayGeometryType,
     terrain3dVisible,
@@ -2509,14 +2508,12 @@ function useDisplayModeStorage() {
     const displayMode = JSON.parse(displayModeStr);
 
     setDisplayDimensions(displayMode.dimensions);
-    if (displayMode.dimensions === '3d') setDisplayDimensionsChanged(true);
     setDisplayGeometryType(displayMode.geometryType);
     setTerrain3dVisible(displayMode.terrain3dVisible);
     setViewUnderground3d(displayMode.viewUnderground3d);
   }, [
     localDisplayModeInitialized,
     setDisplayDimensions,
-    setDisplayDimensionsChanged,
     setDisplayGeometryType,
     setTerrain3dVisible,
     setViewUnderground3d,


### PR DESCRIPTION
## Related Issues:
* [TOTS-12](https://ergcloud.atlassian.net/browse/TOTS-12)

## Main Changes:
* Fixed an issue where the map and or map scalebar overflows into the footer. Especially when switching from 2D to 3D and back to 2D.

## Steps To Test:
1. Navigate to http://localhost:3000/
2. Switch to 3D and then back to 2D
3. Verify the map does not spill over into the footer
4. Resize the window both vertically and horizontally
5. Verify the map does not spill over into the footer
6. Create a sample plan and add a few samples to the map
7. Expand the table
8. Verify the map does not spill over into the footer
9. Resize the table 
10. Verify the map does not spill over into the footer

