### PR TITLE
Feature/59 escape key cancels sketch

### DIFF
--- a/app/client/src/components/App.tsx
+++ b/app/client/src/components/App.tsx
@@ -484,12 +484,12 @@ function App() {
             <SplashScreen />
             <AlertDialog />
             <AlertMessage />
-            {window.location.search.includes('devMode=true') && (
-              <TestingToolbar />
-            )}
             <div css={appStyles(offset)}>
               <div css={containerStyles}>
                 <div ref={toolbarRef}>
+                  {window.location.search.includes('devMode=true') && (
+                    <TestingToolbar />
+                  )}
                   <Toolbar />
                 </div>
                 <NavBar height={contentHeight - toolbarHeight} />

--- a/app/client/src/components/MapMouseEvents.tsx
+++ b/app/client/src/components/MapMouseEvents.tsx
@@ -3,10 +3,11 @@ import * as reactiveUtils from '@arcgis/core/core/reactiveUtils';
 // contexts
 import { SketchContext } from 'contexts/Sketch';
 
-var ctrl = false;
-var shift = false;
-var sketchVMG: __esri.SketchViewModel | null = null;
-var updateGraphics: __esri.Graphic[] = [];
+let ctrl = false;
+let shift = false;
+let sampleAttributesG: any[] = [];
+let sketchVMG: __esri.SketchViewModel | null = null;
+let updateGraphics: __esri.Graphic[] = [];
 
 // Gets the graphic from the hittest
 function getGraphicFromResponse(res: any) {
@@ -29,7 +30,8 @@ type Props = {
 };
 
 function MapMouseEvents({ mapView, sceneView }: Props) {
-  const { setSelectedSampleIds, sketchVM } = useContext(SketchContext);
+  const { sampleAttributes, setSelectedSampleIds, sketchVM } =
+    useContext(SketchContext);
 
   const handleMapClick = useCallback(
     (event: any, view: __esri.MapView | __esri.SceneView) => {
@@ -156,6 +158,16 @@ function MapMouseEvents({ mapView, sceneView }: Props) {
 
       if (event.key === 'Escape' && mapView.popup) {
         mapView.popup.close();
+
+        // re-activate sketch tools if necessary
+        const button = document.querySelector('.sketch-button-selected');
+        if (button?.id && sketchVMG) {
+          const id = button.id;
+
+          // determine whether the sketch button draws points or polygons
+          let shapeType = sampleAttributesG[id as any].ShapeType;
+          sketchVMG.create(shapeType);
+        }
       }
     };
 
@@ -179,6 +191,11 @@ function MapMouseEvents({ mapView, sceneView }: Props) {
 
     setInitialized(true);
   }, [handleMapClick, initialized, mapView, sceneView]);
+
+  // syncs the sampleAttributesG variable with the sampleAttributes context value
+  useEffect(() => {
+    sampleAttributesG = sampleAttributes;
+  }, [sampleAttributes]);
 
   // syncs the sketchVMG variable with the sketchVM context value
   useEffect(() => {

--- a/app/client/src/components/MapWidgets.tsx
+++ b/app/client/src/components/MapWidgets.tsx
@@ -32,7 +32,7 @@ import { SketchContext } from 'contexts/Sketch';
 // types
 import { EditsType } from 'types/Edits';
 import { LayerType, LayerTypeName } from 'types/Layer';
-import { SelectedSampleType } from 'config/sampleAttributes';
+import { PolygonSymbol, SelectedSampleType } from 'config/sampleAttributes';
 // utils
 import { useDynamicPopup, useGeometryTools } from 'utils/hooks';
 import {
@@ -40,6 +40,7 @@ import {
   deactivateButtons,
   generateUUID,
   getCurrentDateTime,
+  getPointSymbol,
   setZValues,
   updateLayerEdits,
 } from 'utils/sketchUtils';
@@ -901,16 +902,12 @@ function MapWidgets({ mapView, sceneView }: Props) {
             pointLayer.removeMany(graphicsToRemove);
 
             // Re-add the point version of the graphic
-            const symbol = graphic.symbol as __esri.SimpleFillSymbol;
+            const symbol = graphic.symbol as any as PolygonSymbol;
             (pointLayer as any).add({
               attributes: graphic.attributes,
               geometry: (graphic.geometry as __esri.Polygon).centroid,
               popupTemplate: graphic.popupTemplate,
-              symbol: {
-                color: symbol.color,
-                outline: symbol.outline,
-                type: 'simple-marker',
-              },
+              symbol: getPointSymbol(graphic, symbol),
             });
           });
         }


### PR DESCRIPTION
## Related Issues:
* [TOTS-59](https://ergcloud.atlassian.net/browse/TOTS-59)

## Main Changes:
* Fixed a bug where hitting the escape key, during sketching, would stop the sketching but leave the sample type button active. I fixed this by automatically re-triggering the sketching. So you start sketching something, hit escape, and then you can immediately start sketching again without clicking any buttons.
* Fixed a bug where the map attribution and table expand buttons were not snapped to the bottom of the map when in `devMode` (screenshot below). 
* Fixed a bug where moving samples on the map would always change the point representation to a circle (gif below). 

## Steps To Test:
1. Navigate to http://localhost:3000/?devMode=true
2. Verify the map attribution and table expand button are snapped to the bottom of the map.
3. Draw an `Aggressive Air` sample on the map
4. Move the symbol by clicking and dragging
5. Verify the symbol stays a triangle
6. Start drawing another symbol and hit the escape key prior to completing the drawing
7. Verify the button stays active after hitting escape
8. Verify that you can still draw on the map


![image](https://github.com/Eastern-Research-Group/Trade-off_Tool_for_Sampling/assets/46329268/514815ef-844f-4dae-a7a0-0a8d659c3480)

![changesToCircle](https://github.com/Eastern-Research-Group/Trade-off_Tool_for_Sampling/assets/46329268/509a1833-6d43-45cb-996c-c214071d2ebf)
