### PR TITLE
Bugfix/55 3d locks up editing

### DIFF
--- a/app/client/src/components/MapWidgets.tsx
+++ b/app/client/src/components/MapWidgets.tsx
@@ -927,7 +927,7 @@ function MapWidgets({ mapView, sceneView }: Props) {
         // prevent scale and reshape changes on the predefined graphics
         // allow moves and rotates
         if (isShapeChange && hasPredefinedBoxes) {
-          sketchViewModel.cancel();
+          sketchViewModel.undo();
         }
 
         setter(isActive);


### PR DESCRIPTION
## Related Issues:
* [TOTS-55](https://ergcloud.atlassian.net/browse/TOTS-55)

## Main Changes:
* Fixed an issue of 3d map locking up after attempting to resize point based polygon (i.e., sponge, micro vac, and swab).
  * I think this was caused by an esri bug around the `cancel` function in 3D. Switching to `undo` fixed the issue.

## Steps To Test: 
1. Switch to 3D view
2. Zoom in as far as possibler
3. Create a plan
4. Place a sponge
5. Switch to polygons view
6. Attempt to resize the polygon

This gif below illustrates how to reproduce the issue. After you attempt to resize the polygon, the map locks up and you can't do anything. Feel free to test this on the dev site to see the bug.
![3dMapLocksUp](https://github.com/Eastern-Research-Group/Trade-off_Tool_for_Sampling/assets/46329268/2b2e6e2c-3e30-41b7-b7cd-1aeebc3826f3)

