### PR TITLE
Feature/53 save calculate results settings

### DIFF
--- a/app/client/src/components/Calculate.tsx
+++ b/app/client/src/components/Calculate.tsx
@@ -154,14 +154,6 @@ function Calculate() {
     setContaminationMap,
     calculateResults,
     setCalculateResults,
-    numLabs,
-    numLabHours,
-    numSamplingHours,
-    numSamplingPersonnel,
-    numSamplingShifts,
-    numSamplingTeams,
-    samplingLaborCost,
-    surfaceArea,
     inputNumLabs,
     setInputNumLabs,
     inputNumLabHours,
@@ -251,6 +243,17 @@ function Calculate() {
       });
       return;
     }
+
+    const {
+      NUM_LABS: numLabs,
+      NUM_LAB_HOURS: numLabHours,
+      NUM_SAMPLING_HOURS: numSamplingHours,
+      NUM_SAMPLING_PERSONNEL: numSamplingPersonnel,
+      NUM_SAMPLING_SHIFTS: numSamplingShifts,
+      NUM_SAMPLING_TEAMS: numSamplingTeams,
+      SAMPLING_LABOR_COST: samplingLaborCost,
+      SURFACE_AREA: surfaceArea,
+    } = selectedScenario.calculateSettings.current;
 
     // if the inputs are the same as context
     // fake a loading spinner and open the panel

--- a/app/client/src/components/Calculate.tsx
+++ b/app/client/src/components/Calculate.tsx
@@ -150,31 +150,72 @@ function Calculate() {
     getGpMaxRecordCount,
   } = useContext(SketchContext);
   const {
-    contaminationMap,
-    setContaminationMap,
     calculateResults,
-    setCalculateResults,
-    inputNumLabs,
-    setInputNumLabs,
+    contaminationMap,
     inputNumLabHours,
-    setInputNumLabHours,
+    inputNumLabs,
     inputNumSamplingHours,
-    setInputNumSamplingHours,
     inputNumSamplingPersonnel,
-    setInputNumSamplingPersonnel,
     inputNumSamplingShifts,
-    setInputNumSamplingShifts,
     inputNumSamplingTeams,
-    setInputNumSamplingTeams,
     inputSamplingLaborCost,
-    setInputSamplingLaborCost,
     inputSurfaceArea,
+    resetCalculateContext,
+    setCalculateResults,
+    setContaminationMap,
+    setInputNumLabHours,
+    setInputNumLabs,
+    setInputNumSamplingHours,
+    setInputNumSamplingPersonnel,
+    setInputNumSamplingShifts,
+    setInputNumSamplingTeams,
+    setInputSamplingLaborCost,
     setInputSurfaceArea,
     setUpdateContextValues,
   } = useContext(CalculateContext);
 
   const getPopupTemplate = useDynamicPopup();
   const services = useServicesContext();
+
+  // sync the inputs with settings pulled from AGO
+  const [pageInitialized, setPageInitialized] = useState(false);
+  useEffect(() => {
+    if (!selectedScenario || pageInitialized) return;
+    setPageInitialized(true);
+
+    const {
+      NUM_LAB_HOURS: numLabHours,
+      NUM_LABS: numLabs,
+      NUM_SAMPLING_HOURS: numSamplingHours,
+      NUM_SAMPLING_PERSONNEL: numSamplingPersonnel,
+      NUM_SAMPLING_SHIFTS: numSamplingShifts,
+      NUM_SAMPLING_TEAMS: numSamplingTeams,
+      SAMPLING_LABOR_COST: samplingLaborCost,
+      SURFACE_AREA: surfaceArea,
+    } = selectedScenario.calculateSettings.current;
+
+    setInputNumLabHours(numLabHours);
+    setInputNumLabs(numLabs);
+    setInputNumSamplingHours(numSamplingHours);
+    setInputNumSamplingPersonnel(numSamplingPersonnel);
+    setInputNumSamplingShifts(numSamplingShifts);
+    setInputNumSamplingTeams(numSamplingTeams);
+    setInputSamplingLaborCost(samplingLaborCost);
+    setInputSurfaceArea(surfaceArea);
+  }, [
+    edits,
+    pageInitialized,
+    resetCalculateContext,
+    selectedScenario,
+    setInputNumLabHours,
+    setInputNumLabs,
+    setInputNumSamplingHours,
+    setInputNumSamplingPersonnel,
+    setInputNumSamplingShifts,
+    setInputNumSamplingTeams,
+    setInputSamplingLaborCost,
+    setInputSurfaceArea,
+  ]);
 
   // callback for closing the results panel when leaving this tab
   const closePanel = useCallback(() => {

--- a/app/client/src/components/EditLayerMetaData.tsx
+++ b/app/client/src/components/EditLayerMetaData.tsx
@@ -9,6 +9,7 @@ import LoadingSpinner from 'components/LoadingSpinner';
 import Select from 'components/Select';
 // contexts
 import { AuthenticationContext } from 'contexts/Authentication';
+import { settingDefaults } from 'contexts/Calculate';
 import { NavigationContext } from 'contexts/Navigation';
 import { PublishContext } from 'contexts/Publish';
 import { SketchContext } from 'contexts/Sketch';
@@ -275,6 +276,7 @@ function EditScenario({
           referenceLayers: [],
         },
         customAttributes: [],
+        calculateSettings: { current: settingDefaults },
       };
 
       // make a copy of the edits context variable

--- a/app/client/src/components/Publish.tsx
+++ b/app/client/src/components/Publish.tsx
@@ -979,7 +979,7 @@ function Publish() {
     let layerEdits: LayerEditsType = {
       type: 'layer',
       id: editsScenario.id,
-      pointsId: -1,
+      pointsId: editsScenario.pointsId,
       uuid: '', // no need for a uuid since this is combining layers into one
       layerId: editsScenario.layerId,
       portalId: editsScenario.portalId,

--- a/app/client/src/components/Publish.tsx
+++ b/app/client/src/components/Publish.tsx
@@ -526,6 +526,7 @@ function Publish() {
         webMapReferenceLayerSelections: [],
         webSceneReferenceLayerSelections: [],
       },
+      calculateSettings: editsScenario.calculateSettings,
     })
       .then((res: any) => {
         const portalId = res.portalId;
@@ -791,6 +792,22 @@ function Publish() {
           });
           editsScenario.table = res.table;
 
+          // find the response for the calculateSettings applyEdits response
+          const calcId = res.calculateSettings.id;
+          const calcRes = res.edits.find((l: any) => l.id === calcId)
+            ?.addResults?.[0];
+
+          if (calcRes) {
+            editsScenario.calculateSettings.current = {
+              ...editsScenario.calculateSettings.current,
+              OBJECTID: calcRes.objectId,
+              GLOBALID: calcRes.globalId,
+            };
+          }
+
+          editsScenario.calculateSettings.published =
+            editsScenario.calculateSettings.current;
+
           return {
             count: edits.count + 1,
             edits: [
@@ -827,6 +844,23 @@ function Publish() {
 
           selectedScenario.status = 'published';
           selectedScenario.portalId = portalId;
+
+          // find the response for the calculateSettings applyEdits response
+          const calcId = res.calculateSettings.id;
+          const calcRes = res.edits.find((l: any) => l.id === calcId)
+            ?.addResults?.[0];
+
+          if (calcRes) {
+            selectedScenario.calculateSettings.current = {
+              ...selectedScenario.calculateSettings.current,
+              OBJECTID: calcRes.objectId,
+              GLOBALID: calcRes.globalId,
+            };
+          }
+
+          selectedScenario.calculateSettings.published =
+            selectedScenario.calculateSettings.current;
+
           return selectedScenario;
         });
       })
@@ -1067,6 +1101,7 @@ function Publish() {
         webMapReferenceLayerSelections,
         webSceneReferenceLayerSelections,
       },
+      calculateSettings: editsScenario.calculateSettings,
     })
       .then((res: any) => {
         const portalId = res.portalId;
@@ -1336,6 +1371,22 @@ function Publish() {
           });
           editsScenario.table = res.table;
 
+          // find the response for the calculateSettings applyEdits response
+          const calcId = res.calculateSettings.id;
+          const calcRes = res.edits.find((l: any) => l.id === calcId)
+            ?.addResults?.[0];
+
+          if (calcRes) {
+            editsScenario.calculateSettings.current = {
+              ...editsScenario.calculateSettings.current,
+              OBJECTID: calcRes.objectId,
+              GLOBALID: calcRes.globalId,
+            };
+          }
+
+          editsScenario.calculateSettings.published =
+            editsScenario.calculateSettings.current;
+
           return {
             count: edits.count + 1,
             edits: [
@@ -1372,6 +1423,23 @@ function Publish() {
 
           selectedScenario.status = 'published';
           selectedScenario.portalId = portalId;
+
+          // find the response for the calculateSettings applyEdits response
+          const calcId = res.calculateSettings.id;
+          const calcRes = res.edits.find((l: any) => l.id === calcId)
+            ?.addResults?.[0];
+
+          if (calcRes) {
+            selectedScenario.calculateSettings.current = {
+              ...selectedScenario.calculateSettings.current,
+              OBJECTID: calcRes.objectId,
+              GLOBALID: calcRes.globalId,
+            };
+          }
+
+          selectedScenario.calculateSettings.published =
+            selectedScenario.calculateSettings.current;
+
           return selectedScenario;
         });
       })

--- a/app/client/src/components/SearchPanel.tsx
+++ b/app/client/src/components/SearchPanel.tsx
@@ -1188,6 +1188,7 @@ function ResultCard({ result }: ResultCardProps) {
 
       const resSampleTypes: any[] = [];
       const resRefLayersTypes: any[] = [];
+      const resCalculateSettings: any[] = [];
       featureLayersRes.tables.forEach((table: any) => {
         if (table.name.endsWith('-sample-types')) {
           resSampleTypes.push(table);
@@ -1195,10 +1196,14 @@ function ResultCard({ result }: ResultCardProps) {
         if (table.name.endsWith('-reference-layers')) {
           resRefLayersTypes.push(table);
         }
+        if (table.name.endsWith('-calculate-settings')) {
+          resCalculateSettings.push(table);
+        }
       });
 
       // fire off the calls with the points layers last
       const resCombined = [
+        ...resCalculateSettings,
         ...resRefLayersTypes,
         ...resSampleTypes,
         ...resPolys,
@@ -1230,6 +1235,7 @@ function ResultCard({ result }: ResultCardProps) {
 
       // define items used for updating states
       let editsCopy: EditsType = deepCopyObject(edits);
+      let calcSettings: any = {};
       const mapLayersToAdd: __esri.Layer[] = [];
       const newAttributes: Attributes = {};
       const newCustomAttributes: AttributesType[] = [];
@@ -1336,6 +1342,14 @@ function ResultCard({ result }: ResultCardProps) {
 
           if (newPortalLayers.length > 0) setPortalLayers(newPortalLayers);
           if (newUrlLayers.length > 0) setUrlLayers(newUrlLayers);
+        } else if (
+          layerDetails.type === 'Table' &&
+          layerDetails.name.endsWith('-calculate-settings') &&
+          layerFeatures.features.length > 0
+        ) {
+          calcSettings = {
+            ...layerFeatures.features[0].attributes,
+          };
         } else if (isPointsSampleLayer || isVspPointsSampleLayer) {
           if (layerFeatures.features?.length > 0) {
             updatePointIds(layerFeatures, layerDetails, layersToAdd, editsCopy);
@@ -1482,6 +1496,10 @@ function ResultCard({ result }: ResultCardProps) {
             table,
             referenceLayersTable,
             customAttributes: newCustomAttributes,
+            calculateSettings: {
+              current: calcSettings,
+              published: calcSettings,
+            },
           };
 
           // make a copy of the edits context variable

--- a/app/client/src/components/SearchPanel.tsx
+++ b/app/client/src/components/SearchPanel.tsx
@@ -1985,6 +1985,11 @@ function ResultCard({ result }: ResultCardProps) {
   function removeTotsLayer() {
     if (!map) return;
 
+    const newEdits = {
+      count: edits.count + 1,
+      edits: edits.edits.filter((layer) => layer.portalId !== result.id),
+    };
+
     setLayers((layers) => {
       // remove the layers from the map and set the next sketchLayer
       const mapLayersToRemove: __esri.Layer[] = [];
@@ -2011,20 +2016,26 @@ function ResultCard({ result }: ResultCardProps) {
         }
       });
 
+      const newLayers = layers.filter((layer) => layer.portalId !== result.id);
+
       // select the next scenario and active sampling layer
       const { nextScenario, nextLayer } = getNextScenarioLayer(
-        edits,
-        layers,
+        newEdits,
+        newLayers,
         null,
         null,
       );
+
       if (nextScenario) setSelectedScenario(nextScenario);
+      else setSelectedScenario(null);
+
       if (nextLayer) setSketchLayer(nextLayer);
+      else setSketchLayer(null);
 
       map.removeMany(mapLayersToRemove);
 
       // set the state
-      return layers.filter((layer) => layer.portalId !== result.id);
+      return newLayers;
     });
 
     setReferenceLayers((layers) => {
@@ -2047,10 +2058,7 @@ function ResultCard({ result }: ResultCardProps) {
     });
 
     // remove the layer from edits
-    setEdits({
-      count: edits.count + 1,
-      edits: edits.edits.filter((layer) => layer.portalId !== result.id),
-    });
+    setEdits(newEdits);
 
     // remove the layer from portal layers
     setPortalLayers((portalLayers) =>

--- a/app/client/src/components/SearchPanel.tsx
+++ b/app/client/src/components/SearchPanel.tsx
@@ -18,6 +18,7 @@ import LoadingSpinner from 'components/LoadingSpinner';
 import Select from 'components/Select';
 // contexts
 import { AuthenticationContext } from 'contexts/Authentication';
+import { settingDefaults } from 'contexts/Calculate';
 import { DialogContext } from 'contexts/Dialog';
 import { useLayerProps, useSampleTypesContext } from 'contexts/LookupFiles';
 import { NavigationContext } from 'contexts/Navigation';
@@ -42,12 +43,13 @@ import {
 } from 'utils/sketchUtils';
 import { createErrorObject, escapeForLucene } from 'utils/utils';
 // types
-import { LayerType, PortalLayerType, UrlLayerType } from 'types/Layer';
 import {
+  CalculateSettingsBaseType,
   EditsType,
   ReferenceLayersTableType,
   ScenarioEditsType,
 } from 'types/Edits';
+import { LayerType, PortalLayerType, UrlLayerType } from 'types/Layer';
 import { ErrorType } from 'types/Misc';
 import { AttributesType } from 'types/Publish';
 import {
@@ -1235,7 +1237,7 @@ function ResultCard({ result }: ResultCardProps) {
 
       // define items used for updating states
       let editsCopy: EditsType = deepCopyObject(edits);
-      let calcSettings: any = {};
+      let calcSettings: CalculateSettingsBaseType | null = null;
       const mapLayersToAdd: __esri.Layer[] = [];
       const newAttributes: Attributes = {};
       const newCustomAttributes: AttributesType[] = [];
@@ -1344,12 +1346,13 @@ function ResultCard({ result }: ResultCardProps) {
           if (newUrlLayers.length > 0) setUrlLayers(newUrlLayers);
         } else if (
           layerDetails.type === 'Table' &&
-          layerDetails.name.endsWith('-calculate-settings') &&
-          layerFeatures.features.length > 0
+          layerDetails.name.endsWith('-calculate-settings')
         ) {
-          calcSettings = {
-            ...layerFeatures.features[0].attributes,
-          };
+          if (layerFeatures.features.length > 0) {
+            calcSettings = {
+              ...layerFeatures.features[0].attributes,
+            };
+          }
         } else if (isPointsSampleLayer || isVspPointsSampleLayer) {
           if (layerFeatures.features?.length > 0) {
             updatePointIds(layerFeatures, layerDetails, layersToAdd, editsCopy);
@@ -1497,8 +1500,8 @@ function ResultCard({ result }: ResultCardProps) {
             referenceLayersTable,
             customAttributes: newCustomAttributes,
             calculateSettings: {
-              current: calcSettings,
-              published: calcSettings,
+              current: calcSettings || settingDefaults,
+              published: calcSettings || undefined,
             },
           };
 

--- a/app/client/src/contexts/Calculate.tsx
+++ b/app/client/src/contexts/Calculate.tsx
@@ -5,34 +5,17 @@ import React, {
   Dispatch,
   ReactNode,
   SetStateAction,
-  useEffect,
   useState,
 } from 'react';
 // types
 import { CalculateResultsType } from 'types/CalculateResults';
 import { LayerType } from 'types/Layer';
 
-type CalculateType = {
+export type CalculateType = {
   calculateResults: CalculateResultsType;
   setCalculateResults: Dispatch<SetStateAction<CalculateResultsType>>;
   contaminationMap: LayerType | null;
   setContaminationMap: Dispatch<SetStateAction<LayerType | null>>;
-  numLabs: number;
-  setNumLabs: Dispatch<SetStateAction<number>>;
-  numLabHours: number;
-  setNumLabHours: Dispatch<SetStateAction<number>>;
-  numSamplingHours: number;
-  setNumSamplingHours: Dispatch<SetStateAction<number>>;
-  numSamplingPersonnel: number;
-  setNumSamplingPersonnel: Dispatch<SetStateAction<number>>;
-  numSamplingShifts: number;
-  setNumSamplingShifts: Dispatch<SetStateAction<number>>;
-  numSamplingTeams: number;
-  setNumSamplingTeams: Dispatch<SetStateAction<number>>;
-  samplingLaborCost: number;
-  setSamplingLaborCost: Dispatch<SetStateAction<number>>;
-  surfaceArea: number;
-  setSurfaceArea: Dispatch<SetStateAction<number>>;
   inputNumLabs: number;
   setInputNumLabs: Dispatch<SetStateAction<number>>;
   inputNumLabHours: number;
@@ -54,42 +37,37 @@ type CalculateType = {
   resetCalculateContext: Function;
 };
 
+export const settingDefaults = {
+  NUM_LABS: 1,
+  NUM_LAB_HOURS: 24,
+  NUM_SAMPLING_HOURS: 5,
+  NUM_SAMPLING_PERSONNEL: 3,
+  NUM_SAMPLING_SHIFTS: 1,
+  NUM_SAMPLING_TEAMS: 1,
+  SAMPLING_LABOR_COST: 420,
+  SURFACE_AREA: 0,
+};
+
 export const CalculateContext = createContext<CalculateType>({
   calculateResults: { status: 'none', panelOpen: false, data: null },
   setCalculateResults: () => {},
   contaminationMap: null,
   setContaminationMap: () => {},
-  numLabs: 1,
-  setNumLabs: () => {},
-  numLabHours: 24,
-  setNumLabHours: () => {},
-  numSamplingHours: 5,
-  setNumSamplingHours: () => {},
-  numSamplingPersonnel: 3,
-  setNumSamplingPersonnel: () => {},
-  numSamplingShifts: 1,
-  setNumSamplingShifts: () => {},
-  numSamplingTeams: 1,
-  setNumSamplingTeams: () => {},
-  samplingLaborCost: 420,
-  setSamplingLaborCost: () => {},
-  surfaceArea: 0,
-  setSurfaceArea: () => {},
-  inputNumLabs: 1,
+  inputNumLabs: settingDefaults.NUM_LABS,
   setInputNumLabs: () => {},
-  inputNumLabHours: 24,
+  inputNumLabHours: settingDefaults.NUM_LAB_HOURS,
   setInputNumLabHours: () => {},
-  inputNumSamplingHours: 5,
+  inputNumSamplingHours: settingDefaults.NUM_SAMPLING_HOURS,
   setInputNumSamplingHours: () => {},
-  inputNumSamplingPersonnel: 3,
+  inputNumSamplingPersonnel: settingDefaults.NUM_SAMPLING_PERSONNEL,
   setInputNumSamplingPersonnel: () => {},
-  inputNumSamplingShifts: 1,
+  inputNumSamplingShifts: settingDefaults.NUM_SAMPLING_SHIFTS,
   setInputNumSamplingShifts: () => {},
-  inputNumSamplingTeams: 1,
+  inputNumSamplingTeams: settingDefaults.NUM_SAMPLING_TEAMS,
   setInputNumSamplingTeams: () => {},
-  inputSamplingLaborCost: 420,
+  inputSamplingLaborCost: settingDefaults.SAMPLING_LABOR_COST,
   setInputSamplingLaborCost: () => {},
-  inputSurfaceArea: 0,
+  inputSurfaceArea: settingDefaults.SURFACE_AREA,
   setInputSurfaceArea: () => {},
   updateContextValues: false,
   setUpdateContextValues: () => {},
@@ -99,79 +77,41 @@ export const CalculateContext = createContext<CalculateType>({
 type Props = { children: ReactNode };
 
 export function CalculateProvider({ children }: Props) {
-  const [
-    calculateResults,
-    setCalculateResults, //
-  ] = useState<CalculateResultsType>({
-    status: 'none',
-    panelOpen: false,
-    data: null,
-  });
-  const [
-    contaminationMap,
-    setContaminationMap, //
-  ] = useState<LayerType | null>(null);
-  const [numLabs, setNumLabs] = useState(1);
-  const [numLabHours, setNumLabHours] = useState(24);
-  const [numSamplingHours, setNumSamplingHours] = useState(5);
-  const [numSamplingPersonnel, setNumSamplingPersonnel] = useState(3);
-  const [numSamplingShifts, setNumSamplingShifts] = useState(1);
-  const [numSamplingTeams, setNumSamplingTeams] = useState(1);
-  const [samplingLaborCost, setSamplingLaborCost] = useState(420);
-  const [surfaceArea, setSurfaceArea] = useState(0);
+  const [calculateResults, setCalculateResults] =
+    useState<CalculateResultsType>({
+      status: 'none',
+      panelOpen: false,
+      data: null,
+    });
+  const [contaminationMap, setContaminationMap] = useState<LayerType | null>(
+    null,
+  );
 
   // input states
-  const [inputNumLabs, setInputNumLabs] = useState(numLabs);
-  const [inputNumLabHours, setInputNumLabHours] = useState(numLabHours);
-  const [inputSurfaceArea, setInputSurfaceArea] = useState(surfaceArea);
-  const [
-    inputNumSamplingHours,
-    setInputNumSamplingHours, //
-  ] = useState(numSamplingHours);
-  const [inputNumSamplingPersonnel, setInputNumSamplingPersonnel] =
-    useState(numSamplingPersonnel);
-  const [
-    inputNumSamplingShifts,
-    setInputNumSamplingShifts, //
-  ] = useState(numSamplingShifts);
-  const [
-    inputNumSamplingTeams,
-    setInputNumSamplingTeams, //
-  ] = useState(numSamplingTeams);
-  const [
-    inputSamplingLaborCost,
-    setInputSamplingLaborCost, //
-  ] = useState(samplingLaborCost);
+  const [inputNumLabs, setInputNumLabs] = useState(settingDefaults.NUM_LABS);
+  const [inputNumLabHours, setInputNumLabHours] = useState(
+    settingDefaults.NUM_LAB_HOURS,
+  );
+  const [inputSurfaceArea, setInputSurfaceArea] = useState(
+    settingDefaults.SURFACE_AREA,
+  );
+  const [inputNumSamplingHours, setInputNumSamplingHours] = useState(
+    settingDefaults.NUM_SAMPLING_HOURS,
+  );
+  const [inputNumSamplingPersonnel, setInputNumSamplingPersonnel] = useState(
+    settingDefaults.NUM_SAMPLING_PERSONNEL,
+  );
+  const [inputNumSamplingShifts, setInputNumSamplingShifts] = useState(
+    settingDefaults.NUM_SAMPLING_SHIFTS,
+  );
+  const [inputNumSamplingTeams, setInputNumSamplingTeams] = useState(
+    settingDefaults.NUM_SAMPLING_TEAMS,
+  );
+  const [inputSamplingLaborCost, setInputSamplingLaborCost] = useState(
+    settingDefaults.SAMPLING_LABOR_COST,
+  );
 
   const [updateContextValues, setUpdateContextValues] = useState(false);
-
-  // Updates the calculation context values with the inputs.
-  // The intention is to update these values whenever the user navigates away from
-  // the calculate resources tab or when they click the View Detailed Results button.
-  useEffect(() => {
-    if (!updateContextValues) return;
-
-    setUpdateContextValues(false);
-
-    setNumLabs(inputNumLabs);
-    setNumLabHours(inputNumLabHours);
-    setNumSamplingHours(inputNumSamplingHours);
-    setNumSamplingPersonnel(inputNumSamplingPersonnel);
-    setNumSamplingShifts(inputNumSamplingShifts);
-    setNumSamplingTeams(inputNumSamplingTeams);
-    setSamplingLaborCost(inputSamplingLaborCost);
-    setSurfaceArea(inputSurfaceArea);
-  }, [
-    inputNumLabs,
-    inputNumLabHours,
-    inputNumSamplingHours,
-    inputNumSamplingPersonnel,
-    inputNumSamplingShifts,
-    inputNumSamplingTeams,
-    inputSamplingLaborCost,
-    inputSurfaceArea,
-    updateContextValues,
-  ]);
 
   return (
     <CalculateContext.Provider
@@ -180,22 +120,6 @@ export function CalculateProvider({ children }: Props) {
         setCalculateResults,
         contaminationMap,
         setContaminationMap,
-        numLabs,
-        setNumLabs,
-        numLabHours,
-        setNumLabHours,
-        numSamplingHours,
-        setNumSamplingHours,
-        numSamplingPersonnel,
-        setNumSamplingPersonnel,
-        numSamplingShifts,
-        setNumSamplingShifts,
-        numSamplingTeams,
-        setNumSamplingTeams,
-        samplingLaborCost,
-        setSamplingLaborCost,
-        surfaceArea,
-        setSurfaceArea,
         inputNumLabs,
         setInputNumLabs,
         inputNumLabHours,
@@ -222,23 +146,14 @@ export function CalculateProvider({ children }: Props) {
           });
           setContaminationMap(null);
 
-          setNumLabs(1);
-          setNumLabHours(24);
-          setNumSamplingHours(5);
-          setNumSamplingPersonnel(3);
-          setNumSamplingShifts(1);
-          setNumSamplingTeams(1);
-          setSamplingLaborCost(420);
-          setSurfaceArea(0);
-
-          setInputNumLabs(1);
-          setInputNumLabHours(24);
-          setInputNumSamplingHours(5);
-          setInputNumSamplingPersonnel(3);
-          setInputNumSamplingShifts(1);
-          setInputNumSamplingTeams(1);
-          setInputSamplingLaborCost(420);
-          setInputSurfaceArea(0);
+          setInputNumLabs(settingDefaults.NUM_LABS);
+          setInputNumLabHours(settingDefaults.NUM_LAB_HOURS);
+          setInputNumSamplingHours(settingDefaults.NUM_SAMPLING_HOURS);
+          setInputNumSamplingPersonnel(settingDefaults.NUM_SAMPLING_PERSONNEL);
+          setInputNumSamplingShifts(settingDefaults.NUM_SAMPLING_SHIFTS);
+          setInputNumSamplingTeams(settingDefaults.NUM_SAMPLING_TEAMS);
+          setInputSamplingLaborCost(settingDefaults.SAMPLING_LABOR_COST);
+          setInputSurfaceArea(settingDefaults.SURFACE_AREA);
         },
       }}
     >

--- a/app/client/src/types/Edits.ts
+++ b/app/client/src/types/Edits.ts
@@ -37,6 +37,24 @@ export type ReferenceLayersTableType = {
   referenceLayers: ReferenceLayerTableType[];
 };
 
+export type CalculateSettingsBaseType = {
+  OBJECTID?: number;
+  GLOBALID?: string;
+  NUM_LABS: number;
+  NUM_LAB_HOURS: number;
+  NUM_SAMPLING_HOURS: number;
+  NUM_SAMPLING_PERSONNEL: number;
+  NUM_SAMPLING_SHIFTS: number;
+  NUM_SAMPLING_TEAMS: number;
+  SAMPLING_LABOR_COST: number;
+  SURFACE_AREA: number;
+};
+
+export type CalculateSettingsType = {
+  current: CalculateSettingsBaseType;
+  published?: CalculateSettingsBaseType;
+};
+
 export type ScenarioEditsType = {
   type: 'scenario';
   id: number; // scenario layer id
@@ -59,6 +77,7 @@ export type ScenarioEditsType = {
   table: TableType | null;
   referenceLayersTable: ReferenceLayersTableType;
   customAttributes: AttributesType[];
+  calculateSettings: CalculateSettingsType;
 };
 
 export type LayerEditsType = {

--- a/app/server/app/public/data/config/layerProps.json
+++ b/app/server/app/public/data/config/layerProps.json
@@ -585,6 +585,150 @@
       "defaultValue": null
     }
   ],
+  "defaultCalculateResultsTableFields": [
+    {
+      "name": "OBJECTID",
+      "type": "esriFieldTypeOID",
+      "actualType": "int",
+      "alias": "OBJECTID",
+      "sqlType": "sqlTypeInteger",
+      "length": 4,
+      "nullable": false,
+      "editable": false,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "GLOBALID",
+      "type": "esriFieldTypeGlobalID",
+      "alias": "GlobalID",
+      "sqlType": "sqlTypeOther",
+      "length": 38,
+      "nullable": false,
+      "editable": false,
+      "domain": null,
+      "defaultValue": "NEWID() WITH VALUES"
+    },
+    {
+      "name": "NUM_LAB_HOURS",
+      "type": "esriFieldTypeInteger",
+      "actualType": "int",
+      "alias": "Analysis Lab Hours per Day",
+      "sqlType": "sqlTypeInteger",
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "NUM_LABS",
+      "type": "esriFieldTypeInteger",
+      "actualType": "int",
+      "alias": "Number of Available Labs for Analysis",
+      "sqlType": "sqlTypeInteger",
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "NUM_SAMPLING_HOURS",
+      "type": "esriFieldTypeInteger",
+      "actualType": "int",
+      "alias": "Sampling Team Hours per Shift",
+      "sqlType": "sqlTypeInteger",
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "NUM_SAMPLING_PERSONNEL",
+      "type": "esriFieldTypeInteger",
+      "actualType": "int",
+      "alias": "Personnel per Sampling Team",
+      "sqlType": "sqlTypeInteger",
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "NUM_SAMPLING_SHIFTS",
+      "type": "esriFieldTypeInteger",
+      "actualType": "int",
+      "alias": "Sampling Team Shifts per Day",
+      "sqlType": "sqlTypeInteger",
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "NUM_SAMPLING_TEAMS",
+      "type": "esriFieldTypeInteger",
+      "actualType": "int",
+      "alias": "Number of Available Teams for Sampling",
+      "sqlType": "sqlTypeInteger",
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "SAMPLING_LABOR_COST",
+      "type": "esriFieldTypeInteger",
+      "actualType": "int",
+      "alias": "Sampling Team Labor Cost ($)",
+      "sqlType": "sqlTypeInteger",
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "SURFACE_AREA",
+      "type": "esriFieldTypeInteger",
+      "actualType": "int",
+      "alias": "Area of Interest Surface Area (ft2)",
+      "sqlType": "sqlTypeInteger",
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "CREATEDDATE",
+      "type": "esriFieldTypeDate",
+      "alias": "CREATEDDATE",
+      "sqlType": "sqlTypeOther",
+      "nullable": true,
+      "editable": false,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "USERNAME",
+      "type": "esriFieldTypeString",
+      "alias": "USERNAME",
+      "sqlType": "sqlTypeOther",
+      "length": 255,
+      "nullable": true,
+      "editable": false,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "UPDATEDDATE",
+      "type": "esriFieldTypeDate",
+      "alias": "UPDATEDDATE",
+      "sqlType": "sqlTypeOther",
+      "nullable": true,
+      "editable": false,
+      "domain": null,
+      "defaultValue": null
+    }
+  ],
   "defaultLayerProps": {
     "type": "Feature Layer",
     "editFieldsInfo": {


### PR DESCRIPTION
## Related Issues:
* [TOTS-53](https://ergcloud.atlassian.net/browse/TOTS-53)

## Main Changes:
* Added calculate settings to the output of the publishing logic.
  * This involved making the settings on the calculate resources tab dependent on the selected sampling plan.

## Steps To Test:
1. Create a sampling plan
2. Add some samples to it
3. Create another sampling plan 
4. Add some samples to it
5. Go to the Calculate Resources tab
6. Change some of the settings
7. Go to Create Plan tab and back to Calculate Resources tab
8. Verify the settings you entered are still there
9. Switch to the other sampling plan you created
10. Verify the settings on the Calculate Resources tab are now the defaults
11. Change the settings on the Calculate Resources tab
12. Publish the output
13. In AGO, verify your calculate settings are in the feature service you just published
14. Back in TOTS, click "Start Over" on the "Create Plan" tab
15. From the "Add Data" tab, add in the layer you just published
16. Go to "Create Plan" tab and select the plan
17. Go to "Calculate Resources" 
18. Verify the settings match what was saved


