### PR TITLE
Feature/57 elevation override

### DIFF
--- a/app/client/src/components/MapPopup.tsx
+++ b/app/client/src/components/MapPopup.tsx
@@ -311,7 +311,7 @@ function MapPopup({
             />
           </div>
           <div>
-            <label htmlFor="graphic-elevation">Elevation: </label>
+            <label htmlFor="graphic-elevation">Elevation (m): </label>
             <br />
             <input
               id="graphic-elevation"

--- a/app/client/src/components/MapPopup.tsx
+++ b/app/client/src/components/MapPopup.tsx
@@ -1,8 +1,9 @@
 /** @jsxImportSource @emotion/react */
 
 import React, {
+  Dispatch,
   Fragment,
-  MouseEvent as ReactMouseEvent,
+  SetStateAction,
   useEffect,
   useState,
 } from 'react';
@@ -71,11 +72,14 @@ const saveButtonStyles = (status: SaveStatusType) => css`
 type Props = {
   features: any[];
   edits: EditsType;
+  setEdits: Dispatch<SetStateAction<EditsType>>;
   layers: LayerType[];
   fieldInfos: FieldInfos;
   layerProps: LookupFile;
   onClick: (
-    ev: ReactMouseEvent<HTMLElement>,
+    edits: EditsType,
+    setEdits: Dispatch<SetStateAction<EditsType>>,
+    layers: LayerType[],
     features: any[],
     type: string,
     newLayer?: LayerType | null,
@@ -85,6 +89,7 @@ type Props = {
 function MapPopup({
   features,
   edits,
+  setEdits,
   layers,
   fieldInfos,
   layerProps,
@@ -331,13 +336,21 @@ function MapPopup({
                       .replace('-points', '')
                       .replace('-hybrid', '')
                   ) {
-                    onClick(ev, features, 'Move', selectedLayer);
+                    onClick(
+                      edits,
+                      setEdits,
+                      layers,
+                      features,
+                      'Move',
+                      selectedLayer,
+                    );
                   } else {
-                    onClick(ev, features, 'Save');
+                    onClick(edits, setEdits, layers, features, 'Save');
                   }
 
                   setSaveStatus('success');
                 } catch (ex) {
+                  console.error(ex);
                   setSaveStatus('failure');
                 }
               }}

--- a/app/client/src/components/MapWidgets.tsx
+++ b/app/client/src/components/MapWidgets.tsx
@@ -52,6 +52,8 @@ type SketchWidgetType = {
   '3d': Sketch;
 };
 
+let terrain3dUseElevationGlobal = true;
+
 // Replaces the prevClassName with nextClassName for all elements with
 // prevClassName on the DOM.
 function replaceClassName(prevClassName: string, nextClassName: string) {
@@ -194,10 +196,17 @@ function MapWidgets({ mapView, sceneView }: Props) {
     map,
     setSelectedSampleIds,
     displayDimensions,
+    terrain3dUseElevation,
   } = useContext(SketchContext);
   const { createBuffer, loadedProjection } = useGeometryTools();
   const getPopupTemplate = useDynamicPopup();
   const layerProps = useLayerProps();
+
+  // Workaround for esri not recognizing React context.
+  // Syncs a global variable with React context.
+  useEffect(() => {
+    terrain3dUseElevationGlobal = terrain3dUseElevation;
+  }, [terrain3dUseElevation]);
 
   // Creates and adds the home widget to the map.
   // Also moves the zoom widget to the top-right
@@ -891,6 +900,7 @@ function MapWidgets({ mapView, sceneView }: Props) {
             map: sketchViewModel.view.map,
             graphic,
             zRefParam: firstPoint,
+            zOverride: terrain3dUseElevationGlobal ? null : 0,
           });
 
           // predefined boxes (sponge, micro vac and swab) need to be

--- a/app/client/src/components/MapWidgets.tsx
+++ b/app/client/src/components/MapWidgets.tsx
@@ -2,7 +2,6 @@
 
 import {
   Dispatch,
-  MouseEvent as ReactMouseEvent,
   SetStateAction,
   useCallback,
   useContext,
@@ -31,7 +30,6 @@ import { useLayerProps } from 'contexts/LookupFiles';
 import { NavigationContext } from 'contexts/Navigation';
 import { SketchContext } from 'contexts/Sketch';
 // types
-import { EditsType } from 'types/Edits';
 import { LayerType, LayerTypeName } from 'types/Layer';
 import { PolygonSymbol, SelectedSampleType } from 'config/sampleAttributes';
 // utils
@@ -42,6 +40,7 @@ import {
   generateUUID,
   getCurrentDateTime,
   getPointSymbol,
+  handlePopupClick,
   setZValues,
   updateLayerEdits,
 } from 'utils/sketchUtils';
@@ -383,126 +382,6 @@ function MapWidgets({ mapView, sceneView }: Props) {
 
     const sketchWidgetLocal = sketchWidget[displayDimensions];
 
-    const handleClick = (
-      ev: ReactMouseEvent<HTMLElement>,
-      features: any[],
-      type: string,
-      newLayer: LayerType | null = null,
-    ) => {
-      if (features?.length > 0 && !features[0].graphic) return;
-
-      // set the clicked button as active until the drawing is complete
-      deactivateButtons();
-
-      let editsCopy: EditsType = edits;
-
-      // find the layer
-      features.forEach((feature) => {
-        const changes = new Collection<__esri.Graphic>();
-        const tempGraphic = feature.graphic;
-        const tempLayer = tempGraphic.layer as __esri.GraphicsLayer;
-        const tempSketchLayer = layers.find(
-          (layer) =>
-            layer.layerId ===
-            tempLayer.id.replace('-points', '').replace('-hybrid', ''),
-        );
-        if (
-          !tempSketchLayer ||
-          tempSketchLayer.sketchLayer.type !== 'graphics'
-        ) {
-          return;
-        }
-
-        // find the graphic
-        const graphic: __esri.Graphic =
-          tempSketchLayer.sketchLayer.graphics.find(
-            (item) =>
-              item.attributes.PERMANENT_IDENTIFIER ===
-              tempGraphic.attributes.PERMANENT_IDENTIFIER,
-          );
-        graphic.attributes = tempGraphic.attributes;
-
-        const pointGraphic: __esri.Graphic | undefined =
-          tempSketchLayer.pointsLayer?.graphics.find(
-            (item) =>
-              item.attributes.PERMANENT_IDENTIFIER ===
-              graphic.attributes.PERMANENT_IDENTIFIER,
-          );
-        if (pointGraphic) pointGraphic.attributes = tempGraphic.attributes;
-
-        const hybridGraphic: __esri.Graphic | undefined =
-          tempSketchLayer.hybridLayer?.graphics.find(
-            (item) =>
-              item.attributes.PERMANENT_IDENTIFIER ===
-              graphic.attributes.PERMANENT_IDENTIFIER,
-          );
-        if (hybridGraphic) hybridGraphic.attributes = tempGraphic.attributes;
-
-        if (type === 'Save') {
-          changes.add(graphic);
-
-          // make a copy of the edits context variable
-          editsCopy = updateLayerEdits({
-            edits: editsCopy,
-            layer: tempSketchLayer,
-            type: 'update',
-            changes,
-          });
-        }
-        if (type === 'Move' && newLayer) {
-          // get items from sketch view model
-          graphic.attributes.DECISIONUNITUUID = newLayer.uuid;
-          graphic.attributes.DECISIONUNIT = newLayer.label;
-          changes.add(graphic);
-
-          // add the graphics to move to the new layer
-          editsCopy = updateLayerEdits({
-            edits: editsCopy,
-            layer: newLayer,
-            type: 'add',
-            changes,
-          });
-
-          // remove the graphics from the old layer
-          editsCopy = updateLayerEdits({
-            edits: editsCopy,
-            layer: tempSketchLayer,
-            type: 'delete',
-            changes,
-          });
-
-          // move between layers on map
-          const tempNewLayer = newLayer.sketchLayer as __esri.GraphicsLayer;
-          tempNewLayer.addMany(changes.toArray());
-          tempSketchLayer.sketchLayer.remove(graphic);
-
-          feature.graphic.layer = newLayer.sketchLayer;
-
-          if (pointGraphic && tempSketchLayer.pointsLayer) {
-            pointGraphic.attributes.DECISIONUNIT = newLayer.label;
-            pointGraphic.attributes.DECISIONUNITUUID = newLayer.uuid;
-
-            const tempNewPointsLayer =
-              newLayer.pointsLayer as __esri.GraphicsLayer;
-            tempNewPointsLayer.add(pointGraphic);
-            tempSketchLayer.pointsLayer.remove(pointGraphic);
-          }
-
-          if (hybridGraphic && tempSketchLayer.hybridLayer) {
-            hybridGraphic.attributes.DECISIONUNIT = newLayer.label;
-            hybridGraphic.attributes.DECISIONUNITUUID = newLayer.uuid;
-
-            const tempNewHybridLayer =
-              newLayer.hybridLayer as __esri.GraphicsLayer;
-            tempNewHybridLayer.add(hybridGraphic);
-            tempSketchLayer.hybridLayer.remove(hybridGraphic);
-          }
-        }
-      });
-
-      setEdits(editsCopy);
-    };
-
     const newSelectedSampleIds = updateGraphics.map((feature) => {
       return {
         PERMANENT_IDENTIFIER: feature.attributes.PERMANENT_IDENTIFIER,
@@ -564,10 +443,11 @@ function MapWidgets({ mapView, sceneView }: Props) {
               };
             })}
             edits={edits}
+            setEdits={setEdits}
             layers={layers}
             fieldInfos={[]}
             layerProps={layerProps}
-            onClick={handleClick}
+            onClick={handlePopupClick}
           />
         );
 

--- a/app/client/src/components/Toolbar.tsx
+++ b/app/client/src/components/Toolbar.tsx
@@ -1006,10 +1006,8 @@ function Toolbar() {
 
             {displayDimensions === '3d' && (
               <Fragment>
-                <div css={switchLabelContainer}>
-                  <label htmlFor="terrain-3d-toggle" css={switchLabel}>
-                    3D Terrain Visible
-                  </label>
+                <label css={switchLabelContainer}>
+                  <span css={switchLabel}>3D Terrain Visible</span>
                   <Switch
                     checked={terrain3dVisible}
                     onChange={(checked) => setTerrain3dVisible(checked)}
@@ -1017,12 +1015,10 @@ function Toolbar() {
                     onColor="#90ee90"
                     onHandleColor="#129c12"
                   />
-                </div>
+                </label>
 
-                <div css={switchLabelContainer}>
-                  <label htmlFor="view-underground-3d-toggle" css={switchLabel}>
-                    3D View Underground
-                  </label>
+                <label css={switchLabelContainer}>
+                  <span css={switchLabel}>3D View Underground</span>
                   <Switch
                     checked={viewUnderground3d}
                     onChange={(checked) => setViewUnderground3d(checked)}
@@ -1030,14 +1026,12 @@ function Toolbar() {
                     onColor="#90ee90"
                     onHandleColor="#129c12"
                   />
-                </div>
+                </label>
               </Fragment>
             )}
 
-            <div css={switchLabelContainer}>
-              <label htmlFor="training-mode-toggle" css={switchLabel}>
-                Training Mode
-              </label>
+            <label css={switchLabelContainer}>
+              <span css={switchLabel}>Training Mode</span>
               <Switch
                 checked={trainingMode}
                 onChange={(checked) => setTrainingMode(checked)}
@@ -1045,12 +1039,10 @@ function Toolbar() {
                 onColor="#90ee90"
                 onHandleColor="#129c12"
               />
-            </div>
+            </label>
 
-            <div css={switchLabelContainer}>
-              <label htmlFor="auto-zoom-toggle" css={switchLabel}>
-                Auto Zoom
-              </label>
+            <label css={switchLabelContainer}>
+              <span css={switchLabel}>Auto Zoom</span>
               <Switch
                 checked={autoZoom}
                 onChange={(checked) => setAutoZoom(checked)}
@@ -1058,7 +1050,7 @@ function Toolbar() {
                 onColor="#90ee90"
                 onHandleColor="#129c12"
               />
-            </div>
+            </label>
           </div>
         </div>
         <div>

--- a/app/client/src/components/Toolbar.tsx
+++ b/app/client/src/components/Toolbar.tsx
@@ -446,6 +446,8 @@ function Toolbar() {
     sceneView,
     displayDimensions,
     setDisplayDimensions,
+    terrain3dUseElevation,
+    setTerrain3dUseElevation,
     terrain3dVisible,
     setTerrain3dVisible,
     viewUnderground3d,
@@ -1012,6 +1014,17 @@ function Toolbar() {
                     checked={terrain3dVisible}
                     onChange={(checked) => setTerrain3dVisible(checked)}
                     ariaLabel="3D Terrain Visible"
+                    onColor="#90ee90"
+                    onHandleColor="#129c12"
+                  />
+                </label>
+
+                <label css={switchLabelContainer}>
+                  <span css={switchLabel}>3D Use Terrain Elevation</span>
+                  <Switch
+                    checked={terrain3dUseElevation}
+                    onChange={(checked) => setTerrain3dUseElevation(checked)}
+                    ariaLabel="3D Use Terrain Elevation"
                     onColor="#90ee90"
                     onHandleColor="#129c12"
                   />

--- a/app/client/src/contexts/Sketch.tsx
+++ b/app/client/src/contexts/Sketch.tsx
@@ -96,6 +96,8 @@ type SketchType = {
   >;
   displayDimensions: '2d' | '3d';
   setDisplayDimensions: Dispatch<SetStateAction<'2d' | '3d'>>;
+  terrain3dUseElevation: boolean;
+  setTerrain3dUseElevation: Dispatch<SetStateAction<boolean>>;
   terrain3dVisible: boolean;
   setTerrain3dVisible: Dispatch<SetStateAction<boolean>>;
   viewUnderground3d: boolean;
@@ -161,6 +163,8 @@ export const SketchContext = createContext<SketchType>({
   setDisplayGeometryType: () => {},
   displayDimensions: '2d',
   setDisplayDimensions: () => {},
+  terrain3dUseElevation: true,
+  setTerrain3dUseElevation: () => {},
   terrain3dVisible: true,
   setTerrain3dVisible: () => {},
   viewUnderground3d: false,
@@ -240,6 +244,7 @@ export function SketchProvider({ children }: Props) {
     'hybrid' | 'points' | 'polygons'
   >('points');
   const [displayDimensions, setDisplayDimensions] = useState<'2d' | '3d'>('2d');
+  const [terrain3dUseElevation, setTerrain3dUseElevation] = useState(true);
   const [terrain3dVisible, setTerrain3dVisible] = useState(true);
   const [viewUnderground3d, setViewUnderground3d] = useState(false);
 
@@ -401,6 +406,8 @@ export function SketchProvider({ children }: Props) {
         setDisplayGeometryType,
         displayDimensions,
         setDisplayDimensions,
+        terrain3dUseElevation,
+        setTerrain3dUseElevation,
         terrain3dVisible,
         setTerrain3dVisible,
         viewUnderground3d,

--- a/app/client/src/utils/hooks.tsx
+++ b/app/client/src/utils/hooks.tsx
@@ -176,6 +176,7 @@ export function useStartOver() {
     setReferenceLayers,
     setSelectedScenario,
     setSketchLayer,
+    setTerrain3dUseElevation,
     setTerrain3dVisible,
     setUrlLayers,
     setUserDefinedAttributes,
@@ -215,6 +216,7 @@ export function useStartOver() {
     setGettingStartedOpen(false);
     setDisplayDimensions('2d');
     setDisplayGeometryType('points');
+    setTerrain3dUseElevation(true);
     setTerrain3dVisible(true);
     setViewUnderground3d(false);
 
@@ -2526,6 +2528,8 @@ function useDisplayModeStorage() {
     setDisplayDimensions,
     displayGeometryType,
     setDisplayGeometryType,
+    terrain3dUseElevation,
+    setTerrain3dUseElevation,
     terrain3dVisible,
     setTerrain3dVisible,
     viewUnderground3d,
@@ -2544,6 +2548,7 @@ function useDisplayModeStorage() {
     if (!displayModeStr) {
       setDisplayDimensions('2d');
       setDisplayGeometryType('points');
+      setTerrain3dUseElevation(true);
       setTerrain3dVisible(true);
       setViewUnderground3d(false);
       return;
@@ -2553,12 +2558,14 @@ function useDisplayModeStorage() {
 
     setDisplayDimensions(displayMode.dimensions);
     setDisplayGeometryType(displayMode.geometryType);
+    setTerrain3dUseElevation(displayMode.terrain3dUseElevation);
     setTerrain3dVisible(displayMode.terrain3dVisible);
     setViewUnderground3d(displayMode.viewUnderground3d);
   }, [
     localDisplayModeInitialized,
     setDisplayDimensions,
     setDisplayGeometryType,
+    setTerrain3dUseElevation,
     setTerrain3dVisible,
     setViewUnderground3d,
   ]);
@@ -2569,6 +2576,7 @@ function useDisplayModeStorage() {
     const displayMode: object = {
       dimensions: displayDimensions,
       geometryType: displayGeometryType,
+      terrain3dUseElevation,
       terrain3dVisible,
       viewUnderground3d,
     };
@@ -2578,6 +2586,7 @@ function useDisplayModeStorage() {
     displayGeometryType,
     localDisplayModeInitialized,
     setOptions,
+    terrain3dUseElevation,
     terrain3dVisible,
     viewUnderground3d,
   ]);

--- a/app/cypress/support/commands.ts
+++ b/app/cypress/support/commands.ts
@@ -106,6 +106,7 @@ Cypress.Commands.add(
         dimensions,
         geometryType: shape,
         terrain3dVisible: terrain3d,
+        terrain3dUseElevation: true,
         viewUnderground3d: false,
       })
     );


### PR DESCRIPTION
## Related Issues:
* [TOTS-57](https://ergcloud.atlassian.net/browse/TOTS-57)

## Main Changes:
* Fixed accessibility issues with labels not being connected to their associated inputs.
* Added the "3D Use Terrain Elevation" setting to allow skipping querying terrain elevation. The elevation is always 0 if this setting is off. 
* Added ability to set the elevation of samples via the popups.


