### PR TITLE
feature/66_blank-coded-value

### DIFF
--- a/app/client/src/components/ConfigureOutput.tsx
+++ b/app/client/src/components/ConfigureOutput.tsx
@@ -1034,6 +1034,9 @@ function EditAttributePopup({
                 dataType.value === 'integer' ||
                 dataType.value === 'string')
             ) {
+              // filter out blank row of coded values
+              const codedValues = codes.filter((c) => c.id !== -1);
+
               if (domainType.value === 'range') {
                 domain = {
                   type: 'range',
@@ -1043,11 +1046,14 @@ function EditAttributePopup({
                   },
                   codedValues: null,
                 };
-              } else if (domainType.value === 'coded') {
+              } else if (
+                domainType.value === 'coded' &&
+                codedValues.length > 0
+              ) {
                 domain = {
                   type: 'coded',
                   range: null,
-                  codedValues: codes,
+                  codedValues,
                 };
               } else {
                 domain = {
@@ -1185,6 +1191,7 @@ function EditAttributePopup({
                 css={inputStyles}
                 value={length}
                 onChange={(ev) => setLength(Number(ev.target.value))}
+                required
               />
             </div>
           )}
@@ -1212,6 +1219,14 @@ function EditAttributePopup({
                 menuPosition={'fixed'}
                 menuPlacement={'bottom'}
               />
+              {/* This is a workaround for an issue where react-select does not
+                allow the required attribute to be passed in. */}
+              <input
+                css={hiddenInput}
+                aria-hidden="true"
+                value={domainType?.label}
+                required
+              />
 
               {domainType?.value === 'range' && (
                 <div css={rangeContainerStyles}>
@@ -1224,6 +1239,7 @@ function EditAttributePopup({
                       css={inputStyles}
                       value={min}
                       onChange={(ev) => setMin(Number(ev.target.value))}
+                      required
                     />
                   </div>
                   <div>
@@ -1235,6 +1251,7 @@ function EditAttributePopup({
                       css={inputStyles}
                       value={max}
                       onChange={(ev) => setMax(Number(ev.target.value))}
+                      required
                     />
                   </div>
                 </div>
@@ -1270,6 +1287,14 @@ function EditAttributePopup({
                         },
                       ];
                     }}
+                  />
+                  {/* This is a workaround for an issue where react-select does not
+                    allow the required attribute to be passed in. */}
+                  <input
+                    css={hiddenInput}
+                    aria-hidden="true"
+                    value={codes.filter((c) => c.id !== -1)[0]?.label}
+                    required
                   />
                 </div>
               )}


### PR DESCRIPTION
## Related Issues:
* [TOTS-66](https://ergcloud.atlassian.net/browse/TOTS-66)

## Main Changes:
* Fixed issue of blank coded values row being included in output.
* Made more fields required (i.e., if a user selects coded values it will be required, if they select none then coded values is not required).

## Steps To Test:
1. Create a plan
2. Add a custom attribute from the configure output tab
3. Select string as the datatype
4. Add coded values to that custom attribute
5. Publish to AGO
6. Open the new layer in field maps
7. Verify the cutsom attribute only has the rows you entered

