### PR TITLE
bugfix/81 contam hits double count

### DIFF
--- a/app/client/src/components/Calculate.tsx
+++ b/app/client/src/components/Calculate.tsx
@@ -494,14 +494,36 @@ function Calculate({ appType }: Props) {
           return;
         }
 
-        resFeatures.push({
-          attributes: {
-            CONTAMTYPE: contamGraphic.attributes.CONTAMTYPE,
-            CONTAMUNIT: contamGraphic.attributes.CONTAMUNIT,
-            CONTAMVAL: contamGraphic.attributes.CONTAMVAL,
-            PERMANENT_IDENTIFIER: sampleGraphic.attributes.PERMANENT_IDENTIFIER,
-          },
-        });
+        const resFeature = resFeatures.find(
+          (feature: any) =>
+            sampleGraphic.attributes.PERMANENT_IDENTIFIER.toLowerCase()
+              .replace('{', '')
+              .replace('}', '') ===
+            feature.attributes.PERMANENT_IDENTIFIER.toLowerCase()
+              .replace('{', '')
+              .replace('}', ''),
+        );
+
+        if (!resFeature) {
+          resFeatures.push({
+            attributes: {
+              CONTAMTYPE: contamGraphic.attributes.CONTAMTYPE,
+              CONTAMUNIT: contamGraphic.attributes.CONTAMUNIT,
+              CONTAMVAL: contamGraphic.attributes.CONTAMVAL,
+              PERMANENT_IDENTIFIER:
+                sampleGraphic.attributes.PERMANENT_IDENTIFIER,
+            },
+          });
+        } else if (
+          resFeature &&
+          resFeature.attributes.CONTAMVAL < contamGraphic.attributes.CONTAMVAL
+        ) {
+          resFeature.attributes.CONTAMTYPE =
+            contamGraphic.attributes.CONTAMTYPE;
+          resFeature.attributes.CONTAMUNIT =
+            contamGraphic.attributes.CONTAMUNIT;
+          resFeature.attributes.CONTAMVAL = contamGraphic.attributes.CONTAMVAL;
+        }
       });
     });
 


### PR DESCRIPTION
## Related Issues:
* [TOTS-81](https://ergcloud.atlassian.net/browse/TOTS-81)

## Main Changes:
* Fixed issue of View Contamination Hits over counting. 

## Steps To Test:
1. Switch to training mode
2. Add a contamination map
3. Add the same thing as a reference layer
4. Place some polygon samples (i.e., wet vac) that straddle multiple contamination plumes
5. Open the Calculate Results panel
6. Click View Contamination Hits
7. Verify the count in the success message matches the number of highlight graphics
    * Note: Previously if you placed one wet vac that straddles three plumes, the success message would say 3 hits instead of 1.
