### PR TITLE
Feature/104 cut out building footprints

### DIFF
--- a/app/client/src/components/Calculate.tsx
+++ b/app/client/src/components/Calculate.tsx
@@ -47,7 +47,7 @@ import {
 // utils
 import { appendEnvironmentObjectParam } from 'utils/arcGisRestUtils';
 import { geoprocessorFetch } from 'utils/fetchUtils';
-import { detectionLimit, useDynamicPopup } from 'utils/hooks';
+import { useDynamicPopup } from 'utils/hooks';
 import {
   generateUUID,
   getGraphicsArray,
@@ -1030,8 +1030,7 @@ function CalculateResultsPopup({
   isOpen,
   onClose,
 }: CalculateResultsPopupProps) {
-  const { edits, jsonDownload, planSettings, efficacyResults } =
-    useContext(SketchContext);
+  const { edits, jsonDownload, planSettings } = useContext(SketchContext);
   const [tableId] = useState(
     `tots-decon-results-selectionstable-${generateUUID()}`,
   );
@@ -1318,35 +1317,6 @@ function CalculateResultsPopup({
       summarySheet.getCell(11, 2).value = Math.round(
         calculateResultsDecon.data['Total Waste Mass'],
       ).toLocaleString();
-
-      if (devMode) {
-        summarySheet.mergeCells(7, 3, 7, 4);
-        summarySheet.getCell(7, 3).alignment = columnTitleAlignment;
-        summarySheet.getCell(7, 3).font = underlinedLabelFont;
-        summarySheet.getCell(7, 3).value = 'Efficacy';
-
-        summarySheet.getCell(8, 3).font = labelFont;
-        summarySheet.getCell(8, 3).value = 'Average Initial Contamination';
-        summarySheet.getCell(8, 4).font = defaultFont;
-        summarySheet.getCell(8, 4).value =
-          `${(efficacyResults?.averageInitialCfu ?? '').toLocaleString()} (CFU/m²)`;
-        summarySheet.getCell(9, 3).font = labelFont;
-        summarySheet.getCell(9, 3).value = 'Average Final Contamination';
-        summarySheet.getCell(9, 4).font = defaultFont;
-        summarySheet.getCell(9, 4).value =
-          `${(efficacyResults?.averageFinalCfu ?? '').toLocaleString()} (CFU/m²)`;
-        summarySheet.getCell(10, 3).font = labelFont;
-        summarySheet.getCell(10, 3).value = 'Detection Limit';
-        summarySheet.getCell(10, 4).font = defaultFont;
-        summarySheet.getCell(10, 4).value = `${detectionLimit} (CFU/m²)`;
-        summarySheet.getCell(11, 3).font = labelFont;
-        summarySheet.getCell(11, 3).value = 'Above/Below Detection Limit';
-        summarySheet.getCell(11, 4).font = defaultFont;
-        summarySheet.getCell(11, 4).value =
-          efficacyResults?.averageFinalCfu >= detectionLimit
-            ? 'Above'
-            : 'Below';
-      }
 
       summarySheet.mergeCells(14, 3, 14, 4);
       summarySheet.getCell(14, 3).alignment = columnTitleAlignment;
@@ -1799,7 +1769,6 @@ function CalculateResultsPopup({
     devMode,
     downloadStatus,
     edits,
-    efficacyResults,
     jsonDownload,
     layers,
     map,
@@ -1892,28 +1861,6 @@ function CalculateResultsPopup({
                   ).toLocaleString()}
                 </div>
               </div>
-              {devMode && efficacyResults && (
-                <div>
-                  <div>
-                    <strong>Average Initial Contamination:</strong>{' '}
-                    {efficacyResults.averageInitialCfu.toLocaleString()}{' '}
-                    (CFU/m²)
-                  </div>
-                  <div>
-                    <strong>Average Final Contamination:</strong>{' '}
-                    {efficacyResults.averageFinalCfu.toLocaleString()} (CFU/m²)
-                  </div>
-                  <div>
-                    <strong>Detection Limit:</strong> {detectionLimit} (CFU/m²)
-                  </div>
-                  <div>
-                    <strong>Above/Below Detection Limit:</strong>{' '}
-                    {efficacyResults.averageFinalCfu >= detectionLimit
-                      ? 'Above'
-                      : 'Below'}
-                  </div>
-                </div>
-              )}
             </div>
           )}
         <br />

--- a/app/client/src/components/Calculate.tsx
+++ b/app/client/src/components/Calculate.tsx
@@ -2122,11 +2122,6 @@ function CalculateResultsPopup({
                       alias: 'Permanent Identifier',
                     },
                     {
-                      name: 'AREA',
-                      type: 'double',
-                      alias: 'AREA',
-                    },
-                    {
                       name: 'CONTAMTYPE',
                       type: 'string',
                       alias: 'Contamination Type',

--- a/app/client/src/components/MapPopup.tsx
+++ b/app/client/src/components/MapPopup.tsx
@@ -538,7 +538,6 @@ export function contaminationMapPopup(feature: any) {
           fieldName: 'ROOFS',
           label: 'Contamination Value Roofs',
         },
-        { label: 'Area', fieldName: 'AREA' },
         { label: 'FID', fieldName: 'FID' },
         { label: 'ID', fieldName: 'Id' },
       ]}

--- a/app/client/src/utils/hooks.tsx
+++ b/app/client/src/utils/hooks.tsx
@@ -241,7 +241,6 @@ function processScenario(
     totalBuildingIntWallsSqM,
     totalBuildingRoofSqM,
   } = planGraphics.summary;
-  const nonBuildingArea = totalAoiSqM - totalBuildingFootprintSqM;
 
   if (isScenario && scenario.aoiSummary) {
     scenario.aoiSummary.area = planGraphics.aoiArea;
@@ -279,7 +278,7 @@ function processScenario(
 
       // get surface area of soil, asphalt or concrete
       //             60 =             100 * 0.6 surface area of concrete
-      surfaceArea = nonBuildingArea * pctFactor;
+      surfaceArea = totalAoiSqM * pctFactor;
 
       // get total CFU for media
       let totalArea = 0;
@@ -563,8 +562,9 @@ async function fetchBuildingData(
       }
 
       const totalArea = planGraphics[planId].aoiArea;
+      const { numAois } = planGraphics[planId].aoiPercentages;
       planGraphics[planId].aoiPercentages = {
-        numAois: 1,
+        numAois,
         asphalt: (imageAreas['asphalt'] / totalArea) * 100,
         concrete: (imageAreas['concrete'] / totalArea) * 100,
         soil:
@@ -1509,7 +1509,7 @@ export function useCalculateDeconPlan() {
   useEffect(() => {
     if (
       ['none', 'success'].includes(calculateResultsDecon.status) ||
-      ['none', 'failure', 'fetching'].includes(nsiData.status)
+      nsiData.status !== 'success'
     )
       return;
 

--- a/app/client/src/utils/hooks.tsx
+++ b/app/client/src/utils/hooks.tsx
@@ -2110,7 +2110,6 @@ export function useCalculateDeconPlan() {
               const geometry = Array.isArray(newOuterContamGeometry)
                 ? newOuterContamGeometry
                 : [newOuterContamGeometry];
-              if (geometry.length > 0) console.log('adding outer...');
               for (const geom of geometry) {
                 newContamGraphics.push(
                   new Graphic({
@@ -2132,7 +2131,6 @@ export function useCalculateDeconPlan() {
               }
             }
 
-            if (innerGeometry.length > 0) console.log('adding inner...');
             for (const geom of innerGeometry) {
               let newCfu = CONTAMVAL;
               if (CONTAMVALEXTWALLS > newCfu) newCfu = CONTAMVALEXTWALLS;


### PR DESCRIPTION
## Related Issues:
* [TOTS-104](https://ergcloud.atlassian.net/browse/TOTS-104)

## Main Changes:
* Updated code to cut building footprints out of imagery analysis in an effert to make calculations more accurate.
* Removed code around calculating efficacy using the contamination map. This was removed because, the results weren't being shown anywhere (it used to be but was removed before the TTX) and the logic for cutting building footprints out of imagery analysis combined with this code causes performance issues.


