### PR TITLE
Feature/143 hide innovative sample types

### DIFF
--- a/app/client/src/components/Calculate.tsx
+++ b/app/client/src/components/Calculate.tsx
@@ -140,18 +140,12 @@ function getOperationSummary(
     let totalOpInitialContamination = 0;
     let totalOpFinalContamination = 0;
     layer.deconLayerResults?.resultsTable.forEach((d) => {
-      totalOpSolidWasteVolume += parseSmallFloat(d.solidWasteVolumeM3, 0);
-      totalOpLiquidWasteVolume += parseSmallFloat(d.liquidWasteVolumeM3, 0);
-      totalOpDeconCost += parseSmallFloat(d.decontaminationCost, 2);
-      totalOpDeconTime += parseSmallFloat(d.decontaminationTimeDays, 1);
-      totalOpInitialContamination += parseSmallFloat(
-        d.averageInitialContamination,
-        0,
-      );
-      totalOpFinalContamination += parseSmallFloat(
-        d.averageFinalContamination,
-        2,
-      );
+      totalOpSolidWasteVolume += d.solidWasteVolumeM3;
+      totalOpLiquidWasteVolume += d.liquidWasteVolumeM3;
+      totalOpDeconCost += d.decontaminationCost;
+      totalOpDeconTime += d.decontaminationTimeDays;
+      totalOpInitialContamination += d.averageInitialContamination;
+      totalOpFinalContamination += d.averageFinalContamination;
     });
 
     totalSolidWasteVolume += totalOpSolidWasteVolume;
@@ -163,26 +157,23 @@ function getOperationSummary(
 
     tableData.push({
       operationName: layer.name,
-      solidWasteVolumeM3: formatNumber(totalOpSolidWasteVolume, -1),
-      liquidWasteVolumeM3: formatNumber(totalOpLiquidWasteVolume, -1),
-      decontaminationCost: formatNumber(totalOpDeconCost, -1),
-      decontaminationTimeDays: formatNumber(totalOpDeconTime, -1),
-      averageInitialContamination: formatNumber(
-        totalOpInitialContamination,
-        -1,
-      ),
-      averageFinalContamination: formatNumber(totalOpFinalContamination, -1),
+      solidWasteVolumeM3: formatNumber(totalOpSolidWasteVolume, 0),
+      liquidWasteVolumeM3: formatNumber(totalOpLiquidWasteVolume, 0),
+      decontaminationCost: formatNumber(totalOpDeconCost, 0),
+      decontaminationTimeDays: formatNumber(totalOpDeconTime, 0),
+      averageInitialContamination: formatNumber(totalOpInitialContamination, 0),
+      averageFinalContamination: formatNumber(totalOpFinalContamination, 0),
       aboveDetectionLimit: '',
     });
   });
   tableData.push({
     operationName: 'TOTALS',
-    solidWasteVolumeM3: formatNumber(totalSolidWasteVolume, -1),
-    liquidWasteVolumeM3: formatNumber(totalLiquidWasteVolume, -1),
-    decontaminationCost: formatNumber(totalDeconCost, -1),
-    decontaminationTimeDays: formatNumber(totalDeconTime, -1),
-    averageInitialContamination: formatNumber(totalInitialContamination, -1),
-    averageFinalContamination: formatNumber(totalFinalContamination, -1),
+    solidWasteVolumeM3: formatNumber(totalSolidWasteVolume, 0),
+    liquidWasteVolumeM3: formatNumber(totalLiquidWasteVolume, 0),
+    decontaminationCost: formatNumber(totalDeconCost, 0),
+    decontaminationTimeDays: formatNumber(totalDeconTime, 0),
+    averageInitialContamination: formatNumber(totalInitialContamination, 0),
+    averageFinalContamination: formatNumber(totalFinalContamination, 0),
     aboveDetectionLimit: '',
   });
 
@@ -2433,7 +2424,9 @@ function CalculateResultsPopup({
                 </div>
                 <div>
                   <strong>Max Time day(s):</strong>{' '}
-                  {calculateResultsDecon.data['TOTAL_TIME'].toLocaleString()}
+                  {Math.round(
+                    calculateResultsDecon.data['TOTAL_TIME'],
+                  ).toLocaleString()}
                 </div>
                 <div>
                   <strong>
@@ -2522,40 +2515,32 @@ function CalculateResultsPopup({
 
           const tableData =
             layer.deconLayerResults?.resultsTable.map((d) => {
-              totalSolidWasteVolume += parseSmallFloat(d.solidWasteVolumeM3, 0);
-              totalSolidWasteMass += parseSmallFloat(d.solidWasteMassKg, 0);
-              totalLiquidWasteVolume += parseSmallFloat(
-                d.liquidWasteVolumeM3,
-                0,
-              );
-              totalLiquidWasteMass += parseSmallFloat(d.liquidWasteMassKg, 0);
-              totalDeconCost += parseSmallFloat(d.decontaminationCost, 2);
-              totalDeconTime += parseSmallFloat(d.decontaminationTimeDays, 1);
-              totalInitialContamination += parseSmallFloat(
-                d.averageInitialContamination,
-                0,
-              );
-              totalFinalContamination += parseSmallFloat(
-                d.averageFinalContamination,
-                2,
-              );
+              totalSolidWasteVolume += d.solidWasteVolumeM3;
+              totalSolidWasteMass += d.solidWasteMassKg;
+              totalLiquidWasteVolume += d.liquidWasteVolumeM3;
+              totalLiquidWasteMass += d.liquidWasteMassKg;
+              totalDeconCost += d.decontaminationCost;
+              totalDeconTime += d.decontaminationTimeDays;
+              totalInitialContamination += d.averageInitialContamination;
+              totalFinalContamination += d.averageFinalContamination;
               return {
                 ...d,
-                solidWasteVolumeM3: formatNumber(d.solidWasteVolumeM3),
-                solidWasteMassKg: formatNumber(d.solidWasteMassKg),
-                liquidWasteVolumeM3: formatNumber(d.liquidWasteVolumeM3),
-                liquidWasteMassKg: formatNumber(d.liquidWasteMassKg),
-                decontaminationCost: formatNumber(d.decontaminationCost, 2),
+                solidWasteVolumeM3: formatNumber(d.solidWasteVolumeM3, 0),
+                solidWasteMassKg: formatNumber(d.solidWasteMassKg, 0),
+                liquidWasteVolumeM3: formatNumber(d.liquidWasteVolumeM3, 0),
+                liquidWasteMassKg: formatNumber(d.liquidWasteMassKg, 0),
+                decontaminationCost: formatNumber(d.decontaminationCost, 0),
                 decontaminationTimeDays: formatNumber(
                   d.decontaminationTimeDays,
-                  1,
+                  0,
                 ),
                 averageInitialContamination: formatNumber(
                   d.averageInitialContamination,
+                  0,
                 ),
                 averageFinalContamination: formatNumber(
                   d.averageFinalContamination,
-                  2,
+                  0,
                 ),
                 aboveDetectionLimit: d.aboveDetectionLimit ? 'Above' : 'Below',
               };
@@ -2563,20 +2548,17 @@ function CalculateResultsPopup({
           tableData.push({
             contaminationScenario: 'TOTALS',
             decontaminationTechnology: '',
-            solidWasteVolumeM3: formatNumber(totalSolidWasteVolume, -1),
-            solidWasteMassKg: formatNumber(totalSolidWasteMass, -1),
-            liquidWasteVolumeM3: formatNumber(totalLiquidWasteVolume, -1),
-            liquidWasteMassKg: formatNumber(totalLiquidWasteMass, -1),
-            decontaminationCost: formatNumber(totalDeconCost, -1),
-            decontaminationTimeDays: formatNumber(totalDeconTime, -1),
+            solidWasteVolumeM3: formatNumber(totalSolidWasteVolume, 0),
+            solidWasteMassKg: formatNumber(totalSolidWasteMass, 0),
+            liquidWasteVolumeM3: formatNumber(totalLiquidWasteVolume, 0),
+            liquidWasteMassKg: formatNumber(totalLiquidWasteMass, 0),
+            decontaminationCost: formatNumber(totalDeconCost, 0),
+            decontaminationTimeDays: formatNumber(totalDeconTime, 0),
             averageInitialContamination: formatNumber(
               totalInitialContamination,
-              -1,
+              0,
             ),
-            averageFinalContamination: formatNumber(
-              totalFinalContamination,
-              -1,
-            ),
+            averageFinalContamination: formatNumber(totalFinalContamination, 0),
             aboveDetectionLimit: '',
             numIterativeApplications: 0,
             numTeams: 0,

--- a/app/client/src/components/CharacterizeAOI.tsx
+++ b/app/client/src/components/CharacterizeAOI.tsx
@@ -1519,6 +1519,11 @@ function CharacterizeAOI({
 
           <AccordionList>
             <AccordionItem title="Advanced Options">
+              <p>
+                A default Ground Sampled Group (GSG) file is included. Click Add
+                to upload an alternative GSG file to support ground surface
+                classification imagery analysis.
+              </p>
               <label htmlFor="gsg-file-select-input">
                 GSG File (optional)
                 <InfoIcon

--- a/app/client/src/components/CreateDeconPlan.tsx
+++ b/app/client/src/components/CreateDeconPlan.tsx
@@ -1767,7 +1767,8 @@ function DeconSelectionPopup({
                   {Math.round(cost).toLocaleString()}
                 </div>
                 <div>
-                  <strong>Max Time day(s):</strong> {time.toLocaleString()}
+                  <strong>Max Time day(s):</strong>{' '}
+                  {Math.round(time).toLocaleString()}
                 </div>
                 <div>
                   <strong>

--- a/app/client/src/components/LocateSamples.tsx
+++ b/app/client/src/components/LocateSamples.tsx
@@ -20,7 +20,7 @@ import { SketchContext } from 'contexts/Sketch';
 import { LayerType } from 'types/Layer';
 import { EditsType, ScenarioEditsType } from 'types/Edits';
 // config
-import { PolygonSymbol } from 'config/sampleAttributes';
+import { PolygonSymbol, SampleSelectType } from 'config/sampleAttributes';
 // utils
 import { use3dSketch, useDynamicPopup, useStartOver } from 'utils/hooks';
 import {
@@ -233,6 +233,12 @@ const deleteButtonStyles = css`
 
 const lineSeparatorStyles = css`
   border-bottom: 1px solid #d8dfe2;
+`;
+
+const sketchGroupingStyles = css`
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 `;
 
 const verticalCenterTextStyles = css`
@@ -448,6 +454,13 @@ function LocateSamples() {
   sampleLayers.push({
     label: 'Unlinked Layers',
     options: getSketchableLayers(layers, edits.edits),
+  });
+
+  const establishedSampleTypes: SampleSelectType[] = [];
+  const innovativeSampleTypes: SampleSelectType[] = [];
+  sampleTypes?.sampleSelectOptions?.forEach((s) => {
+    if (s.isInnovative) innovativeSampleTypes.push(s);
+    else establishedSampleTypes.push(s);
   });
 
   return (
@@ -1410,84 +1423,147 @@ function LocateSamples() {
                     Samples" feature below to add more than one sample point at
                     a time.
                   </p>
-                  <div>
-                    <h3>Established Sample Types</h3>
-                    <div css={sketchButtonContainerStyles}>
-                      {sampleTypes?.sampleSelectOptions.map(
-                        (option: any, index: number) => {
-                          const sampleTypeUuid = option.value;
-                          const sampleType = option.label;
+                  <div css={sketchGroupingStyles}>
+                    {establishedSampleTypes.length > 0 && (
+                      <div>
+                        <h3>Established Sample Types</h3>
+                        <div css={sketchButtonContainerStyles}>
+                          {establishedSampleTypes.map(
+                            (option: any, index: number) => {
+                              const sampleTypeUuid = option.value;
+                              const sampleType = option.label;
 
-                          if (
-                            !Object.prototype.hasOwnProperty.call(
-                              sampleAttributes,
-                              sampleTypeUuid,
-                            )
-                          ) {
-                            return null;
-                          }
+                              if (
+                                !Object.prototype.hasOwnProperty.call(
+                                  sampleAttributes,
+                                  sampleTypeUuid,
+                                )
+                              ) {
+                                return null;
+                              }
 
-                          const shapeType =
-                            sampleAttributes[sampleTypeUuid].ShapeType;
-                          const edited = Object.prototype.hasOwnProperty.call(
-                            userDefinedAttributes.sampleTypes,
-                            sampleTypeUuid,
-                          );
-                          return (
-                            <SketchButton
-                              key={index}
-                              layers={layers}
-                              value={sampleTypeUuid}
-                              selectedScenario={
-                                selectedScenario as ScenarioEditsType
-                              }
-                              label={
-                                edited ? `${sampleType} (edited)` : sampleType
-                              }
-                              iconClass={
-                                shapeType === 'point'
-                                  ? 'fas fa-pen-fancy'
-                                  : 'fas fa-draw-polygon'
-                              }
-                              onClick={() => sketchButtonClick(sampleTypeUuid)}
-                            />
-                          );
-                        },
-                      )}
-                    </div>
-                  </div>
-                  {userDefinedOptions.length > 0 && (
-                    <div>
-                      <br />
-                      <h3>Custom Sample Types</h3>
-                      <div css={sketchButtonContainerStyles}>
-                        {userDefinedOptions.map((option, index) => {
-                          if (option.isPredefined) return null;
-
-                          const sampleTypeUuid = option.value;
-                          const shapeType =
-                            sampleAttributes[sampleTypeUuid as any].ShapeType;
-                          return (
-                            <SketchButton
-                              key={index}
-                              value={sampleTypeUuid}
-                              label={option.label}
-                              layers={layers}
-                              selectedScenario={
-                                selectedScenario as ScenarioEditsType
-                              }
-                              iconClass={
-                                shapeType === 'point'
-                                  ? 'fas fa-pen-fancy'
-                                  : 'fas fa-draw-polygon'
-                              }
-                              onClick={() => sketchButtonClick(sampleTypeUuid)}
-                            />
-                          );
-                        })}
+                              const shapeType =
+                                sampleAttributes[sampleTypeUuid].ShapeType;
+                              const edited =
+                                Object.prototype.hasOwnProperty.call(
+                                  userDefinedAttributes.sampleTypes,
+                                  sampleTypeUuid,
+                                );
+                              return (
+                                <SketchButton
+                                  key={index}
+                                  layers={layers}
+                                  value={sampleTypeUuid}
+                                  selectedScenario={
+                                    selectedScenario as ScenarioEditsType
+                                  }
+                                  label={
+                                    edited
+                                      ? `${sampleType} (edited)`
+                                      : sampleType
+                                  }
+                                  iconClass={
+                                    shapeType === 'point'
+                                      ? 'fas fa-pen-fancy'
+                                      : 'fas fa-draw-polygon'
+                                  }
+                                  onClick={() =>
+                                    sketchButtonClick(sampleTypeUuid)
+                                  }
+                                />
+                              );
+                            },
+                          )}
+                        </div>
                       </div>
-                    </div>
-                  )}
+                    )}
+                    {innovativeSampleTypes.length > 0 && (
+                      <div>
+                        <h3>Innovative Sample Types</h3>
+                        <div css={sketchButtonContainerStyles}>
+                          {innovativeSampleTypes.map(
+                            (option: any, index: number) => {
+                              const sampleTypeUuid = option.value;
+                              const sampleType = option.label;
+
+                              if (
+                                !Object.prototype.hasOwnProperty.call(
+                                  sampleAttributes,
+                                  sampleTypeUuid,
+                                )
+                              ) {
+                                return null;
+                              }
+
+                              const shapeType =
+                                sampleAttributes[sampleTypeUuid].ShapeType;
+                              const edited =
+                                Object.prototype.hasOwnProperty.call(
+                                  userDefinedAttributes.sampleTypes,
+                                  sampleTypeUuid,
+                                );
+                              return (
+                                <SketchButton
+                                  key={index}
+                                  layers={layers}
+                                  value={sampleTypeUuid}
+                                  selectedScenario={
+                                    selectedScenario as ScenarioEditsType
+                                  }
+                                  label={
+                                    edited
+                                      ? `${sampleType} (edited)`
+                                      : sampleType
+                                  }
+                                  iconClass={
+                                    shapeType === 'point'
+                                      ? 'fas fa-pen-fancy'
+                                      : 'fas fa-draw-polygon'
+                                  }
+                                  onClick={() =>
+                                    sketchButtonClick(sampleTypeUuid)
+                                  }
+                                />
+                              );
+                            },
+                          )}
+                        </div>
+                      </div>
+                    )}
+                    {userDefinedOptions.length > 0 && (
+                      <div>
+                        <h3>Custom Sample Types</h3>
+                        <div css={sketchButtonContainerStyles}>
+                          {userDefinedOptions.map((option, index) => {
+                            if (option.isPredefined) return null;
+
+                            const sampleTypeUuid = option.value;
+                            const shapeType =
+                              sampleAttributes[sampleTypeUuid as any].ShapeType;
+                            return (
+                              <SketchButton
+                                key={index}
+                                value={sampleTypeUuid}
+                                label={option.label}
+                                layers={layers}
+                                selectedScenario={
+                                  selectedScenario as ScenarioEditsType
+                                }
+                                iconClass={
+                                  shapeType === 'point'
+                                    ? 'fas fa-pen-fancy'
+                                    : 'fas fa-draw-polygon'
+                                }
+                                onClick={() =>
+                                  sketchButtonClick(sampleTypeUuid)
+                                }
+                              />
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
+                  </div>
                 </div>
               </AccordionItem>
               <AccordionItem title="Add Multiple Random Samples">

--- a/app/client/src/components/NavBar.tsx
+++ b/app/client/src/components/NavBar.tsx
@@ -768,7 +768,7 @@ function NavBar({ appType, height }: Props) {
             height,
             left: expandLeft,
             expanded: true,
-            zIndex: 3,
+            zIndex: 1,
           })}
         >
           <div css={floatPanelButtonContainer(panelExpanded)}>

--- a/app/client/src/components/Publish.tsx
+++ b/app/client/src/components/Publish.tsx
@@ -1881,7 +1881,7 @@ function Publish({ appType }: Props) {
         }
 
         if (
-          (includeAoiCharacterization || isDecon()) &&
+          (includeAoiCharacterization || includePlan) &&
           aoiLayersToInclude.length > 0
         ) {
           aoiLayersToInclude.forEach((aoiLayer) => {
@@ -2202,6 +2202,14 @@ function Publish({ appType }: Props) {
               defaultSymbols.symbols['Staging Area Mask'],
             );
 
+            function addNameDescription(array: any[]) {
+              return array.map((item) => {
+                item.attributes.NAME = stagingAreaLayer.label;
+                item.attributes.DESCRIPTION = stagingAreaLayer.description;
+                return item;
+              });
+            }
+
             featureServices.push({
               category: 'contains-epa-tots-staging-area',
               label: stagingAreaLayer.label,
@@ -2232,10 +2240,10 @@ function Publish({ appType }: Props) {
                       },
                     ],
                   },
-                  adds: stagingAreaLayer.adds,
-                  updates: stagingAreaLayer.updates,
+                  adds: addNameDescription(stagingAreaLayer.adds),
+                  updates: addNameDescription(stagingAreaLayer.updates),
                   deletes: stagingAreaLayer.deletes,
-                  published: stagingAreaLayer.published,
+                  published: addNameDescription(stagingAreaLayer.published),
                 },
               ],
               tables: [],

--- a/app/client/src/components/SearchPanel.tsx
+++ b/app/client/src/components/SearchPanel.tsx
@@ -2980,6 +2980,13 @@ function ResultCard({ appType, result }: ResultCardProps) {
             };
             graphic.popupTemplate = getPopupTemplate(layerType, false);
 
+            if (!graphic.attributes.LATITUDE || !graphic.attributes.LONGITUDE) {
+              graphic.attributes.LATITUDE =
+                (graphic.geometry as __esri.Polygon)?.centroid?.latitude ?? 0;
+              graphic.attributes.LONGITUDE =
+                (graphic.geometry as __esri.Polygon)?.centroid?.longitude ?? 0;
+            }
+
             graphic.symbol = symbol;
             zoomToGraphics.push(graphic);
             graphics.push(graphic);

--- a/app/client/src/components/StagingAreas.tsx
+++ b/app/client/src/components/StagingAreas.tsx
@@ -393,7 +393,7 @@ function StagingAreas() {
         <InfoIcon
           id={'suitability-analysis-layer-info-icon'}
           cssStyles={infoIconStyles}
-          tooltip="A national-level suitability map layer to inform waste<br/>staging/storage location selection based on suitability factors<br/>such as soil type, land cover, topography, ease of transportation,<br/>and proximity to surface waters. Suitability values range from<br/>0 to 500 where higher values (green) or more suitable. You<br/>can use his layer in conjunction with other parcel data to identify<br/>a candidate staging area."
+          tooltip="A national-level suitability map layer to inform waste<br/>staging/storage location selection based on suitability factors<br/>such as soil type, land cover, topography, ease of transportation,<br/>and proximity to surface waters. Suitability values range from<br/>0 to 500 where higher values (green) are more suitable. You<br/>can use this layer in conjunction with other parcel data to identify<br/>a candidate staging area."
         />
       </label>
       <label css={layerItemStyles}>

--- a/app/client/src/components/StagingAreas.tsx
+++ b/app/client/src/components/StagingAreas.tsx
@@ -631,6 +631,10 @@ function useAoiCalculations(aoiLayer?: LayerType | null) {
           AREA: areaSqM,
           SOLID_WASTE_CAPACITY: calculateSolidWasteCapacity(areaSqM),
           LIQUID_WASTE_CAPACITY: calculateLiquidWasteCapacity(areaSqM),
+          LATITUDE:
+            (graphic.geometry as __esri.Polygon)?.centroid?.latitude ?? 0,
+          LONGITUDE:
+            (graphic.geometry as __esri.Polygon)?.centroid?.longitude ?? 0,
         };
       }
     });

--- a/app/client/src/components/StagingAreas.tsx
+++ b/app/client/src/components/StagingAreas.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource @emotion/react */
 
 import { Fragment, useContext, useEffect, useState } from 'react';
+import FeatureLayer from '@arcgis/core/layers/FeatureLayer.js';
 import GraphicsLayer from '@arcgis/core/layers/GraphicsLayer';
 import ImageryLayer from '@arcgis/core/layers/ImageryLayer.js';
-import MapImageLayer from '@arcgis/core/layers/MapImageLayer.js';
 import TileLayer from '@arcgis/core/layers/TileLayer.js';
 import { css } from '@emotion/react';
 // components
@@ -659,9 +659,10 @@ function useGovernmentLandsLayer() {
     if (!map) return;
     return (
       map.findLayerById(GOVERNMENT_LANDS_LAYER_ID) ??
-      new MapImageLayer({
+      new FeatureLayer({
         id: GOVERNMENT_LANDS_LAYER_ID,
         listMode: 'show',
+        title: 'Government-Owned Lands',
         url: services.governmentLands,
       })
     );
@@ -697,6 +698,7 @@ function useParcelLayer() {
       new TileLayer({
         id: PARCEL_LAYER_ID,
         listMode: 'show',
+        title: 'Local Parcel Information',
         url: services.parcel,
       })
     );
@@ -732,6 +734,7 @@ function useSuitabilityLayer() {
       new ImageryLayer({
         id: SUITABILITY_LAYER_ID,
         listMode: 'show',
+        title: 'Staging Suitability Analysis',
         url: services.suitability,
       })
     );

--- a/app/client/src/config/sampleAttributes.ts
+++ b/app/client/src/config/sampleAttributes.ts
@@ -129,5 +129,6 @@ export type SampleIssuesOutput = {
 export type SampleSelectType = {
   value: string;
   label: string;
+  isInnovative?: boolean;
   isPredefined: boolean;
 };

--- a/app/client/src/contexts/LookupFiles.tsx
+++ b/app/client/src/contexts/LookupFiles.tsx
@@ -72,6 +72,10 @@ function useLookupFiles() {
   if (!lookupFilesInitialized) {
     lookupFilesInitialized = true;
 
+    const parseBoolean = (value: string) => {
+      if (value === undefined || value === null) return value;
+      return ['1', 'true', 't'].includes(value.toLowerCase()) ? true : false;
+    };
     const parseNumeric = (value: string) => {
       if (value === undefined || value === null) return value;
       return parseFloat(value);
@@ -105,7 +109,9 @@ function useLookupFiles() {
               DECISIONUNIT: null,
               DECISIONUNITSORT: 0,
               DECISIONUNITUUID: null,
+              ENABLED: parseBoolean(record.ENABLED),
               GLOBALID: null,
+              INNOVATIVE: parseBoolean(record.INNOVATIVE),
               LOD_NON: parseNumeric(record.LOD_NON),
               LOD_P: parseNumeric(record.LOD_P),
               MCPS: parseNumeric(record.MCPS),
@@ -135,9 +141,16 @@ function useLookupFiles() {
 
         const sampleSelectOptions: SampleSelectType[] = [];
         Object.keys(sampleAttributes).forEach((key) => {
+          if (!sampleAttributes[key].ENABLED) return;
           const value = sampleAttributes[key].TYPEUUID;
           const label = sampleAttributes[key].TYPE;
-          sampleSelectOptions.push({ value, label, isPredefined: true });
+          const isInnovative = sampleAttributes[key].INNOVATIVE;
+          sampleSelectOptions.push({
+            value,
+            label,
+            isInnovative,
+            isPredefined: true,
+          });
         });
         const newValue = { ...(data.technologyTypes as SampleTypes) };
         newValue['sampleSelectOptions'] = sampleSelectOptions;
@@ -211,12 +224,14 @@ type RadarContent = {
 type RadarSampleMetadata = {
   ALC: string;
   AMC: string;
+  ENABLED: string;
+  INNOVATIVE: string;
   LOD_NON: string;
   LOD_P: string;
   MCPS: string;
+  Point_Style: string;
   SA: string;
   ShapeType: string;
-  Point_Style: string;
   TCPS: string;
   TTA: string;
   TTC: string;

--- a/app/server/app/public/data/config/layerProps.json
+++ b/app/server/app/public/data/config/layerProps.json
@@ -1912,7 +1912,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "category",
@@ -1935,7 +1935,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "CREATEDDATE",
@@ -2024,7 +2024,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "OCC_CLS",
@@ -2143,7 +2143,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "heightFt",
@@ -2154,7 +2154,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "numStory",
@@ -2165,7 +2165,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "SQMETERS",
@@ -2176,7 +2176,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "SQFEET",
@@ -2187,7 +2187,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "H_ADJ_ELEV",
@@ -2198,7 +2198,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "L_ADJ_ELEV",
@@ -2209,7 +2209,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "FIPS",
@@ -2243,7 +2243,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "SOURCE",
@@ -2278,7 +2278,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "LATITUDE",
@@ -2289,7 +2289,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "IMAGE_NAME",
@@ -2311,7 +2311,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "VAL_METHOD",
@@ -2358,7 +2358,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "footprintSqM",
@@ -2369,7 +2369,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "floorsSqM",
@@ -2380,7 +2380,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "ceilingsSqM",
@@ -2391,7 +2391,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extWallsSqM",
@@ -2402,7 +2402,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intWallsSqM",
@@ -2413,7 +2413,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extVolumeCubM",
@@ -2424,7 +2424,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeCubM",
@@ -2435,7 +2435,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeContentsCubM",
@@ -2446,7 +2446,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "roofSqFt",
@@ -2457,7 +2457,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "footprintSqFt",
@@ -2468,7 +2468,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "floorsSqFt",
@@ -2479,7 +2479,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "ceilingsSqFt",
@@ -2490,7 +2490,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extWallsSqFt",
@@ -2501,7 +2501,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intWallsSqFt",
@@ -2512,7 +2512,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extVolumeCubFt",
@@ -2523,7 +2523,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeCubFt",
@@ -2534,7 +2534,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeContentsCubFt",
@@ -2545,7 +2545,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extBrickSqM",
@@ -2556,7 +2556,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intBrickSqM",
@@ -2567,7 +2567,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extVolumeBrickCubM",
@@ -2578,7 +2578,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeBrickCubM",
@@ -2589,7 +2589,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeBrickContentsCubM",
@@ -2600,7 +2600,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extConcreteSqM",
@@ -2611,7 +2611,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intConcreteSqM",
@@ -2622,7 +2622,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extVolumeConcreteCubM",
@@ -2633,7 +2633,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeConcreteCubM",
@@ -2644,7 +2644,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeConcreteContentsCubM",
@@ -2655,7 +2655,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extSteelSqM",
@@ -2666,7 +2666,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intSteelSqM",
@@ -2677,7 +2677,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extVolumeSteelCubM",
@@ -2688,7 +2688,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeSteelCubM",
@@ -2699,7 +2699,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeSteelContentsCubM",
@@ -2710,7 +2710,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extWoodSqM",
@@ -2721,7 +2721,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intWoodSqM",
@@ -2732,7 +2732,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extVolumeWoodCubM",
@@ -2743,7 +2743,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeWoodCubM",
@@ -2754,7 +2754,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeWoodContentsCubM",
@@ -2765,7 +2765,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extOtherSqM",
@@ -2776,7 +2776,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intOtherSqM",
@@ -2787,7 +2787,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extVolumeOtherCubM",
@@ -2798,7 +2798,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeOtherCubM",
@@ -2809,7 +2809,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeOtherContentsCubM",
@@ -2820,7 +2820,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extBrickSqFt",
@@ -2831,7 +2831,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intBrickSqFt",
@@ -2842,7 +2842,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extVolumeBrickCubFt",
@@ -2853,7 +2853,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeBrickCubFt",
@@ -2864,7 +2864,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeBrickContentsCubFt",
@@ -2875,7 +2875,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extConcreteSqFt",
@@ -2886,7 +2886,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intConcreteSqFt",
@@ -2897,7 +2897,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extVolumeConcreteCubFt",
@@ -2908,7 +2908,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeConcreteCubFt",
@@ -2919,7 +2919,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeConcreteContentsCubFt",
@@ -2930,7 +2930,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extSteelSqFt",
@@ -2941,7 +2941,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intSteelSqFt",
@@ -2952,7 +2952,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extVolumeSteelCubFt",
@@ -2963,7 +2963,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeSteelCubFt",
@@ -2974,7 +2974,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeSteelContentsCubFt",
@@ -2985,7 +2985,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extWoodSqFt",
@@ -2996,7 +2996,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intWoodSqFt",
@@ -3007,7 +3007,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extVolumeWoodCubFt",
@@ -3018,7 +3018,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeWoodCubFt",
@@ -3029,7 +3029,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeWoodContentsCubFt",
@@ -3040,7 +3040,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extOtherSqFt",
@@ -3051,7 +3051,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intOtherSqFt",
@@ -3062,7 +3062,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extVolumeOtherCubFt",
@@ -3073,7 +3073,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeOtherCubFt",
@@ -3084,7 +3084,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intVolumeOtherContentsCubFt",
@@ -3095,7 +3095,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extSqM",
@@ -3106,7 +3106,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "extSqFt",
@@ -3117,7 +3117,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intSqM",
@@ -3128,7 +3128,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "intSqFt",
@@ -3139,7 +3139,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "totalSqM",
@@ -3150,7 +3150,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "totalSqFt",
@@ -3161,7 +3161,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "CONTAMTYPE",
@@ -3274,7 +3274,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "category",
@@ -3297,7 +3297,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "CREATEDDATE",
@@ -3679,6 +3679,30 @@
       "defaultValue": null
     },
     {
+      "name": "NAME",
+      "alias": "Name",
+      "type": "esriFieldTypeString",
+      "actualType": "nvarchar",
+      "sqlType": "sqlTypeNVarchar",
+      "length": 90,
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "DESCRIPTION",
+      "alias": "Description",
+      "type": "esriFieldTypeString",
+      "actualType": "nvarchar",
+      "sqlType": "sqlTypeNVarchar",
+      "length": 2048,
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
       "name": "AREA",
       "alias": "Area (square meters)",
       "type": "esriFieldTypeDouble",
@@ -3687,7 +3711,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "LIQUID_WASTE_CAPACITY",
@@ -3698,7 +3722,7 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
     },
     {
       "name": "SOLID_WASTE_CAPACITY",
@@ -3709,7 +3733,29 @@
       "nullable": true,
       "editable": true,
       "domain": null,
-      "defaultValue": ""
+      "defaultValue": null
+    },
+    {
+      "name": "LATITUDE",
+      "alias": "Latitude of Centroid",
+      "type": "esriFieldTypeDouble",
+      "actualType": "double",
+      "sqlType": "sqlTypeDouble",
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
+    },
+    {
+      "name": "LONGITUDE",
+      "alias": "Longitude of Centroid",
+      "type": "esriFieldTypeDouble",
+      "actualType": "double",
+      "sqlType": "sqlTypeDouble",
+      "nullable": true,
+      "editable": true,
+      "domain": null,
+      "defaultValue": null
     },
     {
       "name": "CREATEDDATE",

--- a/app/server/app/public/data/config/services.json
+++ b/app/server/app/public/data/config/services.json
@@ -1,7 +1,7 @@
 {
   "totsGPServer": "https://geopub.epa.gov/arcgis/rest/services/ORD/TOTS/GPServer",
   "totsTestGPServer": "https://ags.erg.com/arcgis/rest/services/ORD/TOTS/GPServer",
-  "governmentLands": "https://gis.blm.gov/arcgis/rest/services/admin_boundaries/BLM_Natl_AdminUnit/MapServer",
+  "governmentLands": "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Federal_Lands/FeatureServer ",
   "gpServerInputMaxRecordCount": 2000,
   "parcel": "https://tiles.arcgis.com/tiles/KzeiCaQsMoeCfoCq/arcgis/rest/services/Regrid_Nationwide_Parcel_Boundaries_v1/MapServer",
   "proxyUrl": "https://app7.erg.com/PHP/proxy.php?",


### PR DESCRIPTION
## Related Issues:
* [TOTS-86](https://ergcloud.atlassian.net/browse/TOTS-86)
* [TOTS-143](https://ergcloud.atlassian.net/browse/TOTS-143)
* [TOTS-146](https://ergcloud.atlassian.net/browse/TOTS-146)

## Main Changes:
* Added helpful text to the GSG input area.
* Fixed issue of tooltips showing underneath the expand collapse panel buttons.
* Fixed typos in the Suitability Analysis layer tooltip.
* Added name, description and centroid lat/long to the staging area publish output.
* Switched the governmant lands layer to a better one.
* Updated TOTS to hide the innovative sampling methods.
* Added a sample type group for innovative sample types.

