### PR TITLE
Bugfix/162 incorrect decon time total

### DIFF
--- a/app/client/src/components/Calculate.tsx
+++ b/app/client/src/components/Calculate.tsx
@@ -143,7 +143,7 @@ function getOperationSummary(
       totalOpSolidWasteVolume += d.solidWasteVolumeM3;
       totalOpLiquidWasteVolume += d.liquidWasteVolumeM3;
       totalOpDeconCost += d.decontaminationCost;
-      totalOpDeconTime += d.decontaminationTimeDays;
+      totalOpDeconTime = Math.max(d.decontaminationTimeDays, totalOpDeconTime);
       totalOpInitialContamination += d.averageInitialContamination;
       totalOpFinalContamination += d.averageFinalContamination;
     });
@@ -151,7 +151,7 @@ function getOperationSummary(
     totalSolidWasteVolume += totalOpSolidWasteVolume;
     totalLiquidWasteVolume += totalOpLiquidWasteVolume;
     totalDeconCost += totalOpDeconCost;
-    totalDeconTime += totalOpDeconTime;
+    totalDeconTime = Math.max(totalOpDeconTime, totalDeconTime);
     totalInitialContamination += totalOpInitialContamination;
     totalFinalContamination += totalOpFinalContamination;
 
@@ -2520,7 +2520,10 @@ function CalculateResultsPopup({
               totalLiquidWasteVolume += d.liquidWasteVolumeM3;
               totalLiquidWasteMass += d.liquidWasteMassKg;
               totalDeconCost += d.decontaminationCost;
-              totalDeconTime += d.decontaminationTimeDays;
+              totalDeconTime = Math.max(
+                d.decontaminationTimeDays,
+                totalDeconTime,
+              );
               totalInitialContamination += d.averageInitialContamination;
               totalFinalContamination += d.averageFinalContamination;
               return {

--- a/app/client/src/components/LocateSamples.tsx
+++ b/app/client/src/components/LocateSamples.tsx
@@ -159,7 +159,7 @@ function SketchButton({
 
   return (
     <button
-      id={value}
+      id={`draw-sample-${value}`}
       title={`Draw a ${label}: ${count}`}
       className="sketch-button"
       onClick={() => onClick()}
@@ -368,7 +368,7 @@ function LocateSamples() {
     const shapeType = attributes.ShapeType;
 
     // make the style of the button active
-    const wasSet = activateSketchButton(label);
+    const wasSet = activateSketchButton(`draw-sample-${label}`);
 
     // update the sketchVM symbol
     let symbolType = 'Samples';

--- a/app/client/src/components/MapMouseEvents.tsx
+++ b/app/client/src/components/MapMouseEvents.tsx
@@ -5,6 +5,7 @@ import Popup from '@arcgis/core/widgets/Popup';
 import { SketchContext, SketchViewModelType } from 'contexts/Sketch';
 // utils
 import { use3dSketch } from 'utils/hooks';
+import { deactivateButtons } from 'utils/sketchUtils';
 // types
 import { AppType } from 'types/Navigation';
 // config
@@ -181,25 +182,20 @@ function MapMouseEvents({ appType, mapView, sceneView }: Props) {
         if (sceneView) sceneView.closePopup();
 
         // re-activate sketch tools if necessary
+        // TODO figure out how to get this to work for decon and generate random
         if (appType === 'sampling') {
           const button = document.querySelector('.sketch-button-selected');
-          if (button?.id && sketchVMG) {
-            const id = button.id;
-
+          const id = (button?.id ?? '').replace('draw-sample-', '');
+          if (button && button.id.includes('draw-sample-') && sketchVMG) {
             // determine whether the sketch button draws points or polygons
-            const shapeType =
-              id.includes('-sampling-mask') || id.includes('decon-mask')
-                ? 'polygon'
-                : sampleAttributesG[id as any].ShapeType;
+            const shapeType = sampleAttributesG[id as any].ShapeType;
             startSketch(shapeType);
+          } else {
+            deactivateButtons();
           }
         }
         if (appType === 'decon') {
-          const button = document.querySelector('.sketch-button-selected');
-          if (button?.id && sketchVMG) {
-            // determine whether the sketch button draws points or polygons
-            startSketch('polygon');
-          }
+          deactivateButtons();
         }
       }
     };

--- a/app/client/src/components/MapSketchWidgets.tsx
+++ b/app/client/src/components/MapSketchWidgets.tsx
@@ -481,7 +481,7 @@ function MapSketchWidgets({ appType, mapView, sceneView }: Props) {
 
     // get the button and it's id
     const button = document.querySelector('.sketch-button-selected');
-    const id = button && button.id;
+    const id = (button && button.id)?.replace('draw-sample-', '');
     if (id && Object.prototype.hasOwnProperty.call(sampleAttributes, id)) {
       if (appType === 'decon') {
         sketchVM['2d'].cancel();
@@ -626,7 +626,7 @@ function MapSketchWidgets({ appType, mapView, sceneView }: Props) {
         async function processSketchEvent() {
           // get the button and it's id
           const button = document.querySelector('.sketch-button-selected');
-          const id = button && button.id;
+          const id = (button && button.id)?.replace('draw-sample-', '');
           if (
             id?.includes('-sampling-mask') ||
             id?.includes('decon-mask') ||

--- a/app/client/src/components/Publish.tsx
+++ b/app/client/src/components/Publish.tsx
@@ -2316,6 +2316,7 @@ function Publish({ appType }: Props) {
           portal,
           map,
           featureServices,
+          layerProps,
         });
         console.log('responses: ', responses);
 

--- a/app/client/src/components/Publish.tsx
+++ b/app/client/src/components/Publish.tsx
@@ -1458,7 +1458,7 @@ function Publish({ appType }: Props) {
                 totalLiquidWaste += tech.liquidWasteVolumeM3;
                 totalLiquidWasteMass += tech.liquidWasteMassKg;
                 totalCost += tech.decontaminationCost;
-                totalTime += tech.decontaminationTimeDays;
+                totalTime = Math.max(tech.decontaminationTimeDays, totalTime);
                 calculationResults.push({
                   OPERATION_UUID: linkedLayer.layerId,
                   AGGREGATION_LEVEL: 'RAW',
@@ -1503,7 +1503,7 @@ function Publish({ appType }: Props) {
               totalLiquidWaste += summary.AQUEOUS_WASTE_M3;
               totalLiquidWasteMass += summary.AQUEOUS_WASTE_MASS;
               totalCost += summary.COST;
-              totalTime += summary.TIME;
+              totalTime = Math.max(summary.TIME, totalTime);
             });
 
             calculationResultsSummary.push({

--- a/app/client/src/contexts/Publish.tsx
+++ b/app/client/src/contexts/Publish.tsx
@@ -7,6 +7,7 @@ import React, {
   SetStateAction,
   useState,
 } from 'react';
+import { isDecon } from 'styles';
 // types
 import { ServiceMetaDataType } from 'types/Edits';
 import {
@@ -39,8 +40,8 @@ const defaultConfigureOutputValue: DefaultConfigureOutput = {
   includeAoiCharacterization: false,
   includeCustomSampleTypes: false,
   includePlan: false,
-  includePlanWebMap: false,
-  includePlanWebScene: false,
+  includePlanWebMap: isDecon() ? false : true,
+  includePlanWebScene: isDecon() ? false : true,
   includeStagingAreas: false,
   selectedAoiCharacterizations: [],
   selectedStagingAreas: [],

--- a/app/client/src/types/Misc.ts
+++ b/app/client/src/types/Misc.ts
@@ -20,6 +20,8 @@ export type LayerProps = {
   defaultContaminationMapLayerFields: __esri.FieldProperties[];
   defaultLayerProps: __esri.FeatureLayerProperties;
   defaultTableProps: any;
+  defaultWebMapProps: any;
+  defaultWebSceneProps: any;
   webMapFieldProps: any;
 };
 

--- a/app/client/src/utils/arcGisRestUtils.ts
+++ b/app/client/src/utils/arcGisRestUtils.ts
@@ -8,105 +8,6 @@ import { fetchPost, fetchCheck } from 'utils/fetchUtils';
 import { generateUUID, getCurrentDateTime } from 'utils/sketchUtils';
 import { chunkArray, escapeForLucene } from 'utils/utils';
 
-const webMapProps = {
-  version: '2.27',
-  authoringApp: 'ArcGISMapViewer',
-  authoringAppVersion: '2023.1',
-  baseMap: {
-    baseMapLayers: [
-      {
-        id: 'VectorTile_9568',
-        title: 'World Topographic Map',
-        itemId: '27e89eb03c1e4341a1d75e597f0291e6',
-        layerType: 'VectorTileLayer',
-        styleUrl:
-          'https://www.arcgis.com/sharing/rest/content/items/27e89eb03c1e4341a1d75e597f0291e6/resources/styles/root.json',
-      },
-    ],
-    title: 'Topographic',
-  },
-  initialState: {},
-  spatialReference: {
-    latestWkid: 3857,
-    wkid: 102100,
-  },
-};
-
-const webSceneProps = {
-  version: '1.30',
-  authoringApp: 'WebSceneViewer',
-  authoringAppVersion: '2023.1.0',
-  baseMap: {
-    baseMapLayers: [
-      {
-        id: 'World_Hillshade_3805',
-        opacity: 1,
-        title: 'World Hillshade',
-        url: 'https://services.arcgisonline.com/arcgis/rest/services/Elevation/World_Hillshade/MapServer',
-        visibility: true,
-        layerType: 'ArcGISTiledMapServiceLayer',
-      },
-      {
-        id: '195012aeb31-layer-2',
-        title: 'World Topographic Map',
-        itemId: '27e89eb03c1e4341a1d75e597f0291e6',
-        layerType: 'VectorTileLayer',
-        styleUrl:
-          'https://www.arcgis.com/sharing/rest/content/items/27e89eb03c1e4341a1d75e597f0291e6/resources/styles/root.json',
-      },
-    ],
-    id: '1866114cb4d-basemap-0',
-    title: 'Topographic',
-    elevationLayers: [
-      {
-        id: 'globalElevation',
-        listMode: 'show',
-        title: 'Terrain3D',
-        url: 'https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer',
-        layerType: 'ArcGISTiledElevationServiceLayer',
-      },
-    ],
-  },
-  ground: {
-    layers: [
-      {
-        id: 'globalElevation',
-        listMode: 'show',
-        title: 'Terrain3D',
-        url: 'https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer',
-        layerType: 'ArcGISTiledElevationServiceLayer',
-      },
-    ],
-    transparency: 0,
-    navigationConstraint: {
-      type: 'none',
-    },
-  },
-  heightModelInfo: {
-    heightModel: 'gravity_related_height',
-    heightUnit: 'meter',
-  },
-  initialState: {
-    environment: {
-      lighting: {
-        type: 'sun',
-        datetime: 1678899363000,
-        displayUTCOffset: -5,
-      },
-      atmosphereEnabled: true,
-      starsEnabled: true,
-      weather: {
-        type: 'sunny',
-        cloudCover: 0.5,
-      },
-    },
-  },
-  spatialReference: {
-    latestWkid: 3857,
-    wkid: 102100,
-  },
-};
-
 /**
  * Changes the layer name such that it will work with ArcGIS Online
  *
@@ -536,7 +437,7 @@ export function buildRendererParams(
   const sampleTypes: any = {};
 
   // get the extent from the array of graphics
-  if (layer.sketchLayer.type === 'graphics') {
+  if (layer.sketchLayer?.type === 'graphics') {
     layer.sketchLayer.graphics.forEach((graphic) => {
       if (graphicsExtent === null) graphicsExtent = graphic.geometry.extent;
       else graphicsExtent.union(graphic.geometry.extent);
@@ -621,7 +522,7 @@ export function buildRendererParams(
       }
     });
   }
-  if (layer.sketchLayer.type === 'feature') {
+  if (layer.sketchLayer?.type === 'feature') {
     graphicsExtent = layer.sketchLayer.fullExtent;
   }
 
@@ -1324,7 +1225,7 @@ export function addPointFeatures(
   }
 
   let attributes: any = {};
-  if (layer?.sketchLayer.type === 'graphics') {
+  if (layer?.sketchLayer?.type === 'graphics') {
     const graphic = layer.sketchLayer.graphics.find(
       (graphic) =>
         graphic.attributes.PERMANENT_IDENTIFIER ===
@@ -1754,6 +1655,7 @@ function buildReferenceLayers(
  * @param layersResponse The response from creating layers
  * @param referenceMaterials Reference layers to apply to web map
  * @param map Esri Map - Used for sorting the reference layers
+ * @param layerProps The layer properties to be used for publishing
  * @param type Web Map or Web Scene
  * @param existingWebMapScene Object for existing web map or web scene, if available
  * @returns A promise that resolves to the successfully saved web map
@@ -1765,6 +1667,7 @@ function addWebMapScene({
   layersResponse,
   referenceMaterials,
   map,
+  layerProps,
   type,
   existingWebMapScene,
 }: {
@@ -1774,6 +1677,7 @@ function addWebMapScene({
   layersResponse: any;
   referenceMaterials: ReferenceLayerSelections[];
   map: __esri.Map;
+  layerProps: LayerProps;
   type: 'Web Map' | 'Web Scene';
   existingWebMapScene: any | null;
 }) {
@@ -1864,7 +1768,10 @@ function addWebMapScene({
     });
     console.log('operationalLayers: ', operationalLayers);
 
-    const webProps = type === 'Web Map' ? webMapProps : webSceneProps;
+    const webProps =
+      type === 'Web Map'
+        ? layerProps.defaultWebMapProps
+        : layerProps.defaultWebSceneProps;
 
     // run the webserivce call to update ArcGIS Online
     const data = {
@@ -1922,16 +1829,19 @@ function addWebMapScene({
  * @param portal The portal object to apply edits to
  * @param map Esri Map - Used for sorting the reference layers
  * @param featureService Object detailing information about the feature service to be published.
+ * @param layerProps The layer properties to be used for publishing
  * @returns A promise that resolves to the successfully published data
  */
 async function publishFeatureService({
   portal,
   map,
   featureService,
+  layerProps,
 }: {
   portal: __esri.Portal;
   map: __esri.Map;
   featureService: any;
+  layerProps: LayerProps;
 }) {
   const service = await getFeatureService(portal, featureService);
 
@@ -2008,6 +1918,7 @@ async function publishFeatureService({
       referenceMaterials:
         featureService.referenceMaterials.webMapReferenceLayerSelections,
       map,
+      layerProps,
       existingWebMapScene: webMapRes,
     });
   }
@@ -2028,6 +1939,7 @@ async function publishFeatureService({
       referenceMaterials:
         featureService.referenceMaterials.webSceneReferenceLayerSelections,
       map,
+      layerProps,
       existingWebMapScene: webSceneRes,
     });
   }
@@ -2053,16 +1965,19 @@ async function publishFeatureService({
  * @param portal The portal object to apply edits to
  * @param map Esri Map - Used for sorting the reference layers
  * @param featureService Object detailing information about the feature service to be published.
+ * @param layerProps The layer properties to be used for publishing
  * @returns A promise that resolves to the successfully published data
  */
 export async function publish({
   portal,
   map,
   featureServices,
+  layerProps,
 }: {
   portal: __esri.Portal;
   map: __esri.Map;
   featureServices: any[];
+  layerProps: LayerProps;
 }) {
   if (featureServices.length === 0) return 'Nothing to publish.';
 
@@ -2141,6 +2056,7 @@ export async function publish({
         portal,
         map,
         featureService,
+        layerProps,
       });
       requests.push(request);
 

--- a/app/client/src/utils/arcGisRestUtils.ts
+++ b/app/client/src/utils/arcGisRestUtils.ts
@@ -17,9 +17,10 @@ const webMapProps = {
       {
         id: 'VectorTile_9568',
         title: 'World Topographic Map',
+        itemId: '27e89eb03c1e4341a1d75e597f0291e6',
         layerType: 'VectorTileLayer',
         styleUrl:
-          'https://cdn.arcgis.com/sharing/rest/content/items/42df0d22517e49ad84edcee4c093857d/resources/styles/root.json',
+          'https://www.arcgis.com/sharing/rest/content/items/27e89eb03c1e4341a1d75e597f0291e6/resources/styles/root.json',
       },
     ],
     title: 'Topographic',
@@ -38,10 +39,20 @@ const webSceneProps = {
   baseMap: {
     baseMapLayers: [
       {
-        id: '1866114cd76-layer-1',
-        title: 'World Topo Map',
-        url: 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer',
+        id: 'World_Hillshade_3805',
+        opacity: 1,
+        title: 'World Hillshade',
+        url: 'https://services.arcgisonline.com/arcgis/rest/services/Elevation/World_Hillshade/MapServer',
+        visibility: true,
         layerType: 'ArcGISTiledMapServiceLayer',
+      },
+      {
+        id: '195012aeb31-layer-2',
+        title: 'World Topographic Map',
+        itemId: '27e89eb03c1e4341a1d75e597f0291e6',
+        layerType: 'VectorTileLayer',
+        styleUrl:
+          'https://www.arcgis.com/sharing/rest/content/items/27e89eb03c1e4341a1d75e597f0291e6/resources/styles/root.json',
       },
     ],
     id: '1866114cb4d-basemap-0',

--- a/app/client/src/utils/hooks.tsx
+++ b/app/client/src/utils/hooks.tsx
@@ -2305,7 +2305,7 @@ export function useCalculateDeconPlan() {
                 false,
               );
               deconCost += calcOutput.deconCost;
-              deconTime += calcOutput.deconTime;
+              deconTime = Math.max(calcOutput.deconTime, deconTime);
               solidWasteM3 += calcOutput.solidWasteM3;
               liquidWasteM3 += calcOutput.liquidWasteM3;
               solidWasteMass += calcOutput.solidWasteMass;
@@ -2329,7 +2329,7 @@ export function useCalculateDeconPlan() {
                 media,
               );
               deconCost += calcOutput.deconCost;
-              deconTime += calcOutput.deconTime;
+              deconTime = Math.max(calcOutput.deconTime, deconTime);
               solidWasteM3 += calcOutput.solidWasteM3;
               liquidWasteM3 += calcOutput.liquidWasteM3;
               solidWasteMass += calcOutput.solidWasteMass;
@@ -2353,7 +2353,10 @@ export function useCalculateDeconPlan() {
 
           if (deconOp.deconLayerResults) {
             deconOp.deconLayerResults.cost += deconCost;
-            deconOp.deconLayerResults.time += deconTime;
+            deconOp.deconLayerResults.time = Math.max(
+              deconTime,
+              deconOp.deconLayerResults.time,
+            );
             deconOp.deconLayerResults.wasteVolume +=
               solidWasteM3 + liquidWasteM3;
             deconOp.deconLayerResults.wasteMass +=
@@ -2365,7 +2368,7 @@ export function useCalculateDeconPlan() {
           totalSolidWasteMass += solidWasteMass;
           totalLiquidWasteMass += liquidWasteMass;
           totalDeconCost += deconCost;
-          totalDeconTime += deconTime;
+          totalDeconTime = Math.max(deconTime, totalDeconTime);
         });
 
         deconOp.deconLayerResults.resultsTable = jsonDownloadOpLevel;

--- a/app/client/src/utils/hooks.tsx
+++ b/app/client/src/utils/hooks.tsx
@@ -3708,8 +3708,8 @@ export function useAutoConfigureOutput() {
   useEffect(() => {
     let includeAoiCharacterization = false;
     let includePlan = false;
-    let includePlanWebMap = false;
-    let includePlanWebScene = false;
+    let includePlanWebMap = isDecon() ? false : true;
+    let includePlanWebScene = isDecon() ? false : true;
     let includeStagingAreas = false;
     const selectedAoiCharacterizations: Selections = [];
     const selectedStagingAreas: Selections = [];

--- a/app/client/src/utils/hooks.tsx
+++ b/app/client/src/utils/hooks.tsx
@@ -3514,7 +3514,7 @@ export function use3dSketch(appType: AppType) {
 
       // get the button and it's id
       const button = document.querySelector('.sketch-button-selected');
-      const id = button && button.id;
+      const id = (button && button.id)?.replace('draw-sample-', '');
       if (id?.includes('-sampling-mask') || id?.includes('decon-mask')) {
         deactivateButtons();
       }

--- a/app/server/app/public/data/config/layerProps.json
+++ b/app/server/app/public/data/config/layerProps.json
@@ -4113,6 +4113,101 @@
     "capabilities": "Create,Delete,Query,Update,Editing,Extract,Sync",
     "exceedsLimitFactor": 1
   },
+  "defaultWebMapProps": {
+    "version": "2.33",
+    "authoringApp": "ArcGISMapViewer",
+    "authoringAppVersion": "2025.1",
+    "baseMap": {
+      "baseMapLayers": [
+        {
+          "id": "VectorTile_9568",
+          "title": "World Topographic Map",
+          "itemId": "27e89eb03c1e4341a1d75e597f0291e6",
+          "layerType": "VectorTileLayer",
+          "styleUrl": "https://www.arcgis.com/sharing/rest/content/items/27e89eb03c1e4341a1d75e597f0291e6/resources/styles/root.json"
+        }
+      ],
+      "title": "Topographic"
+    },
+    "initialState": {},
+    "spatialReference": {
+      "latestWkid": 3857,
+      "wkid": 102100
+    }
+  },
+  "defaultWebSceneProps": {
+    "version": "1.36",
+    "authoringApp": "WebSceneViewer",
+    "authoringAppVersion": "2025.1.0",
+    "baseMap": {
+      "baseMapLayers": [
+        {
+          "id": "World_Hillshade_3805",
+          "opacity": 1,
+          "title": "World Hillshade",
+          "url": "https://services.arcgisonline.com/arcgis/rest/services/Elevation/World_Hillshade/MapServer",
+          "visibility": true,
+          "layerType": "ArcGISTiledMapServiceLayer"
+        },
+        {
+          "id": "195012aeb31-layer-2",
+          "title": "World Topographic Map",
+          "itemId": "27e89eb03c1e4341a1d75e597f0291e6",
+          "layerType": "VectorTileLayer",
+          "styleUrl": "https://www.arcgis.com/sharing/rest/content/items/27e89eb03c1e4341a1d75e597f0291e6/resources/styles/root.json"
+        }
+      ],
+      "id": "1866114cb4d-basemap-0",
+      "title": "Topographic",
+      "elevationLayers": [
+        {
+          "id": "globalElevation",
+          "listMode": "show",
+          "title": "Terrain3D",
+          "url": "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer",
+          "layerType": "ArcGISTiledElevationServiceLayer"
+        }
+      ]
+    },
+    "ground": {
+      "layers": [
+        {
+          "id": "globalElevation",
+          "listMode": "show",
+          "title": "Terrain3D",
+          "url": "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer",
+          "layerType": "ArcGISTiledElevationServiceLayer"
+        }
+      ],
+      "transparency": 0,
+      "navigationConstraint": {
+        "type": "none"
+      }
+    },
+    "heightModelInfo": {
+      "heightModel": "gravity_related_height",
+      "heightUnit": "meter"
+    },
+    "initialState": {
+      "environment": {
+        "lighting": {
+          "type": "sun",
+          "datetime": 1678899363000,
+          "displayUTCOffset": -5
+        },
+        "atmosphereEnabled": true,
+        "starsEnabled": true,
+        "weather": {
+          "type": "sunny",
+          "cloudCover": 0.5
+        }
+      }
+    },
+    "spatialReference": {
+      "latestWkid": 3857,
+      "wkid": 102100
+    }
+  },
   "webMapFieldProps": {
     "OBJECTID": {
       "fieldName": "OBJECTID",


### PR DESCRIPTION
## Related Issues:
* [TOTS-162](https://ergcloud.atlassian.net/browse/TOTS-162)
* [TOTS-166](https://ergcloud.atlassian.net/browse/TOTS-166)
* [TOTS-168](https://ergcloud.atlassian.net/browse/TOTS-168)

## Main Changes:
* Fixed issue of having to click "Draw Area of Interest" twice to activate sketching, after canceling a sketch.
* Fixed issue of total time in decon assuming sequential operations (i.e., total is all of the time added up instead of just being the max value).
* Updated basemap of published web map/scene to have gulf of america.
* Updated web map/scene publishing to pull base props from a config file.

